### PR TITLE
Fix Keycloak/OPA healthchecks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,10 +70,15 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && cat <&3 | grep -q '200'"]
+      test:
+        [
+          "CMD-SHELL",
+          "if command -v curl >/dev/null; then curl -fsS http://localhost:8080/health/ready; elif command -v wget >/dev/null; then wget -q --spider http://localhost:8080/health/ready; else exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && cat <&3 | grep -q '200'; fi",
+        ]
       interval: 10s
       timeout: 5s
       retries: 12
+      start_period: 60s
     networks:
       - dpp-network
 
@@ -99,6 +104,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
     networks:
       - dpp-network
 


### PR DESCRIPTION
Updates healthchecks to avoid startup deadlocks and add start_period for Keycloak/OPA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced health verification for services with multiple fallback methods to ensure robust startup detection.
  * Extended startup grace periods for improved service initialization reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->