### PR TITLE
Implement CEN prEN 18219/18220/18222 compliance layer

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,12 +16,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install Syft (retry)
+        run: |
+          set -euo pipefail
+          SYFT_VERSION="v1.31.0"
+          for attempt in 1 2 3; do
+            echo "Installing Syft ${SYFT_VERSION} (attempt ${attempt}/3)"
+            if curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+              | sh -s -- -b "${HOME}/.local/bin" "${SYFT_VERSION}"; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "Failed to install Syft after 3 attempts"
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
       - name: Generate SBOM (SPDX JSON)
-        uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad # v0
-        with:
-          path: .
-          format: spdx-json
-          output-file: sbom.spdx.json
+        run: syft . -o spdx-json=sbom.spdx.json
       - name: Upload SBOM
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -840,6 +840,26 @@ class Settings(BaseSettings):
     # ==========================================================================
     # Identifier Configuration
     # ==========================================================================
+    cen_dpp_enabled: bool = Field(
+        default=False,
+        description="Enable CEN prEN profile routes and validations",
+    )
+    cen_profile_18219: str = Field(
+        default="prEN18219:2025-07",
+        description="Active CEN profile version for unique identifiers",
+    )
+    cen_profile_18220: str = Field(
+        default="prEN18220:2025-07",
+        description="Active CEN profile version for data carriers",
+    )
+    cen_profile_18222: str = Field(
+        default="prEN18222:2025-07",
+        description="Active CEN profile version for API facade behavior",
+    )
+    cen_allow_http_identifiers: bool = Field(
+        default=False,
+        description="Allow http scheme for CEN identifier canonicalization (default: https-only)",
+    )
     global_asset_id_base_uri_default: str = Field(
         default="http://localhost:8000/asset/",
         description="Default base URI for globalAssetId generation",

--- a/backend/app/db/migrations/versions/0041_cen_identifier_governance.py
+++ b/backend/app/db/migrations/versions/0041_cen_identifier_governance.py
@@ -75,11 +75,17 @@ def upgrade() -> None:
             nullable=False,
             server_default="self_issued",
         ),
-        sa.Column("canonicalization_rules", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "canonicalization_rules", postgresql.JSONB(astext_type=sa.Text()), nullable=False
+        ),
         sa.Column("validation_rules", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
         sa.Column("openness_metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("code", name="uq_identifier_schemes_code"),
     )
@@ -121,7 +127,9 @@ def upgrade() -> None:
         sa.Column("value_canonical", sa.Text(), nullable=False),
         sa.Column(
             "granularity",
-            postgresql.ENUM("model", "batch", "item", name="datacarrieridentitylevel", create_type=False),
+            postgresql.ENUM(
+                "model", "batch", "item", name="datacarrieridentitylevel", create_type=False
+            ),
             nullable=True,
         ),
         sa.Column(
@@ -145,8 +153,12 @@ def upgrade() -> None:
         sa.Column("issued_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("deprecates_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("created_by_subject", sa.String(length=255), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "scheme_code",
@@ -167,14 +179,18 @@ def upgrade() -> None:
             nullable=False,
             index=True,
         ),
-        sa.Column("dpp_id", sa.UUID(), sa.ForeignKey("dpps.id", ondelete="CASCADE"), nullable=False),
+        sa.Column(
+            "dpp_id", sa.UUID(), sa.ForeignKey("dpps.id", ondelete="CASCADE"), nullable=False
+        ),
         sa.Column(
             "external_identifier_id",
             sa.UUID(),
             sa.ForeignKey("external_identifiers.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("dpp_id", "external_identifier_id", name="uq_dpp_identifier_link"),
     )

--- a/backend/app/db/migrations/versions/0041_cen_identifier_governance.py
+++ b/backend/app/db/migrations/versions/0041_cen_identifier_governance.py
@@ -1,0 +1,265 @@
+"""Add CEN identifier governance tables and seed baseline schemes.
+
+Revision ID: 0041_cen_identifier_governance
+Revises: 0040_crypto_hardening
+Create Date: 2026-02-21
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0041_cen_identifier_governance"
+down_revision = "0040_crypto_hardening"
+branch_labels = None
+depends_on = None
+
+
+def _enable_tenant_rls(table_name: str) -> None:
+    op.execute(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE {table_name} FORCE ROW LEVEL SECURITY")
+    op.execute(
+        f"""
+        CREATE POLICY {table_name}_tenant_isolation
+        ON {table_name}
+        USING (tenant_id = current_setting('app.current_tenant', true)::uuid)
+        """
+    )
+
+
+def _disable_tenant_rls(table_name: str) -> None:
+    op.execute(f"DROP POLICY IF EXISTS {table_name}_tenant_isolation ON {table_name}")
+    op.execute(f"ALTER TABLE {table_name} NO FORCE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE {table_name} DISABLE ROW LEVEL SECURITY")
+
+
+def upgrade() -> None:
+    sa.Enum("product", "operator", "facility", name="identifierentitytype").create(
+        op.get_bind(),
+        checkfirst=True,
+    )
+    sa.Enum("issuing_agency", "self_issued", "hybrid", name="identifierissuancemodel").create(
+        op.get_bind(),
+        checkfirst=True,
+    )
+    sa.Enum("active", "deprecated", "withdrawn", name="externalidentifierstatus").create(
+        op.get_bind(),
+        checkfirst=True,
+    )
+
+    op.create_table(
+        "identifier_schemes",
+        sa.Column("id", sa.UUID(), server_default=sa.text("uuid_generate_v7()"), nullable=False),
+        sa.Column("code", sa.String(length=64), nullable=False),
+        sa.Column(
+            "entity_type",
+            postgresql.ENUM(
+                "product",
+                "operator",
+                "facility",
+                name="identifierentitytype",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "issuance_model",
+            postgresql.ENUM(
+                "issuing_agency",
+                "self_issued",
+                "hybrid",
+                name="identifierissuancemodel",
+                create_type=False,
+            ),
+            nullable=False,
+            server_default="self_issued",
+        ),
+        sa.Column("canonicalization_rules", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("validation_rules", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("openness_metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("code", name="uq_identifier_schemes_code"),
+    )
+    op.create_index("ix_identifier_schemes_entity_type", "identifier_schemes", ["entity_type"])
+    op.create_index(
+        "ix_identifier_schemes_issuance_model",
+        "identifier_schemes",
+        ["issuance_model"],
+    )
+
+    op.create_table(
+        "external_identifiers",
+        sa.Column("id", sa.UUID(), server_default=sa.text("uuid_generate_v7()"), nullable=False),
+        sa.Column(
+            "tenant_id",
+            sa.UUID(),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "entity_type",
+            postgresql.ENUM(
+                "product",
+                "operator",
+                "facility",
+                name="identifierentitytype",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "scheme_code",
+            sa.String(length=64),
+            sa.ForeignKey("identifier_schemes.code", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("value_raw", sa.Text(), nullable=False),
+        sa.Column("value_canonical", sa.Text(), nullable=False),
+        sa.Column(
+            "granularity",
+            postgresql.ENUM("model", "batch", "item", name="datacarrieridentitylevel", create_type=False),
+            nullable=True,
+        ),
+        sa.Column(
+            "status",
+            postgresql.ENUM(
+                "active",
+                "deprecated",
+                "withdrawn",
+                name="externalidentifierstatus",
+                create_type=False,
+            ),
+            nullable=False,
+            server_default="active",
+        ),
+        sa.Column(
+            "replaced_by_identifier_id",
+            sa.UUID(),
+            sa.ForeignKey("external_identifiers.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("issued_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("deprecates_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_by_subject", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "scheme_code",
+            "value_canonical",
+            name="uq_external_identifiers_scheme_value",
+        ),
+    )
+    op.create_index("ix_external_identifiers_entity_type", "external_identifiers", ["entity_type"])
+    op.create_index("ix_external_identifiers_status", "external_identifiers", ["status"])
+
+    op.create_table(
+        "dpp_identifiers",
+        sa.Column("id", sa.UUID(), server_default=sa.text("uuid_generate_v7()"), nullable=False),
+        sa.Column(
+            "tenant_id",
+            sa.UUID(),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("dpp_id", sa.UUID(), sa.ForeignKey("dpps.id", ondelete="CASCADE"), nullable=False),
+        sa.Column(
+            "external_identifier_id",
+            sa.UUID(),
+            sa.ForeignKey("external_identifiers.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("dpp_id", "external_identifier_id", name="uq_dpp_identifier_link"),
+    )
+    op.create_index("ix_dpp_identifiers_dpp", "dpp_identifiers", ["dpp_id"])
+    op.create_index(
+        "ix_dpp_identifiers_external_identifier",
+        "dpp_identifiers",
+        ["external_identifier_id"],
+    )
+
+    for table_name in ("external_identifiers", "dpp_identifiers"):
+        _enable_tenant_rls(table_name)
+
+    op.execute(
+        """
+        INSERT INTO identifier_schemes (
+            code, entity_type, issuance_model, canonicalization_rules, validation_rules, openness_metadata
+        )
+        VALUES
+            (
+                'gs1_gtin', 'product', 'issuing_agency',
+                '{"digits_only": true, "trim": true}',
+                '{"gtin_check_digit": true}',
+                '{"resolver": "gs1_digital_link"}'
+            ),
+            (
+                'iec61406', 'product', 'hybrid',
+                '{"uri_normalization": true, "trim": true}',
+                '{"required_fields": ["manufacturer_part_id"]}',
+                '{"resolver": "iec61406_identification_link"}'
+            ),
+            (
+                'direct_url', 'product', 'self_issued',
+                '{"uri_normalization": true, "trim": true}',
+                '{"allowed_schemes": ["https", "http"]}',
+                '{"resolver": "direct"}'
+            ),
+            (
+                'uri', 'operator', 'self_issued',
+                '{"uri_normalization": true, "trim": true}',
+                '{"allowed_schemes": ["https", "http"]}',
+                '{"resolver": "external"}'
+            ),
+            (
+                'gln', 'facility', 'issuing_agency',
+                '{"digits_only": true, "trim": true}',
+                '{"length": [13]}',
+                '{"resolver": "gs1"}'
+            ),
+            (
+                'eori', 'operator', 'issuing_agency',
+                '{"uppercase": true, "trim": true}',
+                '{"min_length": 8}',
+                '{"resolver": "eu_customs"}'
+            )
+        ON CONFLICT (code) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    for table_name in ("dpp_identifiers", "external_identifiers"):
+        _disable_tenant_rls(table_name)
+
+    op.drop_index("ix_dpp_identifiers_external_identifier", table_name="dpp_identifiers")
+    op.drop_index("ix_dpp_identifiers_dpp", table_name="dpp_identifiers")
+    op.drop_table("dpp_identifiers")
+
+    op.drop_index("ix_external_identifiers_status", table_name="external_identifiers")
+    op.drop_index("ix_external_identifiers_entity_type", table_name="external_identifiers")
+    op.drop_table("external_identifiers")
+
+    op.drop_index("ix_identifier_schemes_issuance_model", table_name="identifier_schemes")
+    op.drop_index("ix_identifier_schemes_entity_type", table_name="identifier_schemes")
+    op.drop_table("identifier_schemes")
+
+    sa.Enum("active", "deprecated", "withdrawn", name="externalidentifierstatus").drop(
+        op.get_bind(),
+        checkfirst=True,
+    )
+    sa.Enum("issuing_agency", "self_issued", "hybrid", name="identifierissuancemodel").drop(
+        op.get_bind(),
+        checkfirst=True,
+    )
+    sa.Enum("product", "operator", "facility", name="identifierentitytype").drop(
+        op.get_bind(),
+        checkfirst=True,
+    )

--- a/backend/app/db/migrations/versions/0042_cen_operator_facility_entities.py
+++ b/backend/app/db/migrations/versions/0042_cen_operator_facility_entities.py
@@ -49,8 +49,12 @@ def upgrade() -> None:
         sa.Column("country", sa.String(length=8), nullable=True),
         sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
         sa.Column("created_by_subject", sa.String(length=255), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(
@@ -80,8 +84,12 @@ def upgrade() -> None:
         sa.Column("address", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
         sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
         sa.Column("created_by_subject", sa.String(length=255), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index("ix_facilities_operator", "facilities", ["operator_id"])
@@ -109,7 +117,9 @@ def upgrade() -> None:
             sa.ForeignKey("external_identifiers.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "operator_id",
@@ -146,7 +156,9 @@ def upgrade() -> None:
             sa.ForeignKey("external_identifiers.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "facility_id",

--- a/backend/app/db/migrations/versions/0042_cen_operator_facility_entities.py
+++ b/backend/app/db/migrations/versions/0042_cen_operator_facility_entities.py
@@ -1,0 +1,202 @@
+"""Add CEN operator/facility entities and identifier link tables.
+
+Revision ID: 0042_cen_operator_facility_entities
+Revises: 0041_cen_identifier_governance
+Create Date: 2026-02-21
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0042_cen_operator_facility_entities"
+down_revision = "0041_cen_identifier_governance"
+branch_labels = None
+depends_on = None
+
+
+def _enable_tenant_rls(table_name: str) -> None:
+    op.execute(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE {table_name} FORCE ROW LEVEL SECURITY")
+    op.execute(
+        f"""
+        CREATE POLICY {table_name}_tenant_isolation
+        ON {table_name}
+        USING (tenant_id = current_setting('app.current_tenant', true)::uuid)
+        """
+    )
+
+
+def _disable_tenant_rls(table_name: str) -> None:
+    op.execute(f"DROP POLICY IF EXISTS {table_name}_tenant_isolation ON {table_name}")
+    op.execute(f"ALTER TABLE {table_name} NO FORCE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE {table_name} DISABLE ROW LEVEL SECURITY")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "economic_operators",
+        sa.Column("id", sa.UUID(), server_default=sa.text("uuid_generate_v7()"), nullable=False),
+        sa.Column(
+            "tenant_id",
+            sa.UUID(),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("legal_name", sa.String(length=255), nullable=False),
+        sa.Column("country", sa.String(length=8), nullable=True),
+        sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("created_by_subject", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_economic_operators_tenant_name",
+        "economic_operators",
+        ["tenant_id", "legal_name"],
+    )
+    op.create_index("ix_economic_operators_country", "economic_operators", ["country"])
+
+    op.create_table(
+        "facilities",
+        sa.Column("id", sa.UUID(), server_default=sa.text("uuid_generate_v7()"), nullable=False),
+        sa.Column(
+            "tenant_id",
+            sa.UUID(),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "operator_id",
+            sa.UUID(),
+            sa.ForeignKey("economic_operators.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("facility_name", sa.String(length=255), nullable=False),
+        sa.Column("address", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("created_by_subject", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_facilities_operator", "facilities", ["operator_id"])
+    op.create_index("ix_facilities_tenant_name", "facilities", ["tenant_id", "facility_name"])
+
+    op.create_table(
+        "operator_identifiers",
+        sa.Column("id", sa.UUID(), server_default=sa.text("uuid_generate_v7()"), nullable=False),
+        sa.Column(
+            "tenant_id",
+            sa.UUID(),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "operator_id",
+            sa.UUID(),
+            sa.ForeignKey("economic_operators.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "external_identifier_id",
+            sa.UUID(),
+            sa.ForeignKey("external_identifiers.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "operator_id",
+            "external_identifier_id",
+            name="uq_operator_identifier_link",
+        ),
+    )
+    op.create_index("ix_operator_identifiers_operator", "operator_identifiers", ["operator_id"])
+    op.create_index(
+        "ix_operator_identifiers_external_identifier",
+        "operator_identifiers",
+        ["external_identifier_id"],
+    )
+
+    op.create_table(
+        "facility_identifiers",
+        sa.Column("id", sa.UUID(), server_default=sa.text("uuid_generate_v7()"), nullable=False),
+        sa.Column(
+            "tenant_id",
+            sa.UUID(),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "facility_id",
+            sa.UUID(),
+            sa.ForeignKey("facilities.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "external_identifier_id",
+            sa.UUID(),
+            sa.ForeignKey("external_identifiers.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "facility_id",
+            "external_identifier_id",
+            name="uq_facility_identifier_link",
+        ),
+    )
+    op.create_index("ix_facility_identifiers_facility", "facility_identifiers", ["facility_id"])
+    op.create_index(
+        "ix_facility_identifiers_external_identifier",
+        "facility_identifiers",
+        ["external_identifier_id"],
+    )
+
+    for table_name in (
+        "economic_operators",
+        "facilities",
+        "operator_identifiers",
+        "facility_identifiers",
+    ):
+        _enable_tenant_rls(table_name)
+
+
+def downgrade() -> None:
+    for table_name in (
+        "facility_identifiers",
+        "operator_identifiers",
+        "facilities",
+        "economic_operators",
+    ):
+        _disable_tenant_rls(table_name)
+
+    op.drop_index(
+        "ix_facility_identifiers_external_identifier",
+        table_name="facility_identifiers",
+    )
+    op.drop_index("ix_facility_identifiers_facility", table_name="facility_identifiers")
+    op.drop_table("facility_identifiers")
+
+    op.drop_index(
+        "ix_operator_identifiers_external_identifier",
+        table_name="operator_identifiers",
+    )
+    op.drop_index("ix_operator_identifiers_operator", table_name="operator_identifiers")
+    op.drop_table("operator_identifiers")
+
+    op.drop_index("ix_facilities_tenant_name", table_name="facilities")
+    op.drop_index("ix_facilities_operator", table_name="facilities")
+    op.drop_table("facilities")
+
+    op.drop_index("ix_economic_operators_country", table_name="economic_operators")
+    op.drop_index("ix_economic_operators_tenant_name", table_name="economic_operators")
+    op.drop_table("economic_operators")

--- a/backend/app/db/migrations/versions/0042_cen_operator_facility_entities.py
+++ b/backend/app/db/migrations/versions/0042_cen_operator_facility_entities.py
@@ -1,6 +1,6 @@
 """Add CEN operator/facility entities and identifier link tables.
 
-Revision ID: 0042_cen_operator_facility_entities
+Revision ID: 0042_cen_operator_facility
 Revises: 0041_cen_identifier_governance
 Create Date: 2026-02-21
 """
@@ -10,7 +10,7 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = "0042_cen_operator_facility_entities"
+revision = "0042_cen_operator_facility"
 down_revision = "0041_cen_identifier_governance"
 branch_labels = None
 depends_on = None

--- a/backend/app/db/migrations/versions/0043_cen_carrier_qa_and_binding.py
+++ b/backend/app/db/migrations/versions/0043_cen_carrier_qa_and_binding.py
@@ -1,0 +1,117 @@
+"""Add CEN data carrier binding and quality-check support.
+
+Revision ID: 0043_cen_carrier_qa_and_binding
+Revises: 0042_cen_operator_facility_entities
+Create Date: 2026-02-21
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0043_cen_carrier_qa_and_binding"
+down_revision = "0042_cen_operator_facility_entities"
+branch_labels = None
+depends_on = None
+
+
+def _enable_tenant_rls(table_name: str) -> None:
+    op.execute(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE {table_name} FORCE ROW LEVEL SECURITY")
+    op.execute(
+        f"""
+        CREATE POLICY {table_name}_tenant_isolation
+        ON {table_name}
+        USING (tenant_id = current_setting('app.current_tenant', true)::uuid)
+        """
+    )
+
+
+def _disable_tenant_rls(table_name: str) -> None:
+    op.execute(f"DROP POLICY IF EXISTS {table_name}_tenant_isolation ON {table_name}")
+    op.execute(f"ALTER TABLE {table_name} NO FORCE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE {table_name} DISABLE ROW LEVEL SECURITY")
+
+
+def upgrade() -> None:
+    op.add_column(
+        "data_carriers",
+        sa.Column(
+            "external_identifier_id",
+            sa.UUID(),
+            sa.ForeignKey("external_identifiers.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "data_carriers",
+        sa.Column("payload_sha256", sa.String(length=64), nullable=True),
+    )
+    op.create_index(
+        "ix_data_carriers_external_identifier_id",
+        "data_carriers",
+        ["external_identifier_id"],
+    )
+
+    op.create_table(
+        "data_carrier_quality_checks",
+        sa.Column("id", sa.UUID(), server_default=sa.text("uuid_generate_v7()"), nullable=False),
+        sa.Column(
+            "tenant_id",
+            sa.UUID(),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "carrier_id",
+            sa.UUID(),
+            sa.ForeignKey("data_carriers.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("check_type", sa.String(length=64), nullable=False),
+        sa.Column("passed", sa.Boolean(), nullable=False),
+        sa.Column("results", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("performed_by_subject", sa.String(length=255), nullable=False),
+        sa.Column("performed_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_data_carrier_quality_checks_carrier_id",
+        "data_carrier_quality_checks",
+        ["carrier_id"],
+    )
+    op.create_index(
+        "ix_data_carrier_quality_checks_check_type",
+        "data_carrier_quality_checks",
+        ["check_type"],
+    )
+    op.create_index(
+        "ix_data_carrier_quality_checks_performed_at",
+        "data_carrier_quality_checks",
+        ["performed_at"],
+    )
+    _enable_tenant_rls("data_carrier_quality_checks")
+
+
+def downgrade() -> None:
+    _disable_tenant_rls("data_carrier_quality_checks")
+
+    op.drop_index(
+        "ix_data_carrier_quality_checks_performed_at",
+        table_name="data_carrier_quality_checks",
+    )
+    op.drop_index(
+        "ix_data_carrier_quality_checks_check_type",
+        table_name="data_carrier_quality_checks",
+    )
+    op.drop_index(
+        "ix_data_carrier_quality_checks_carrier_id",
+        table_name="data_carrier_quality_checks",
+    )
+    op.drop_table("data_carrier_quality_checks")
+
+    op.drop_index("ix_data_carriers_external_identifier_id", table_name="data_carriers")
+    op.drop_column("data_carriers", "payload_sha256")
+    op.drop_column("data_carriers", "external_identifier_id")

--- a/backend/app/db/migrations/versions/0043_cen_carrier_qa_and_binding.py
+++ b/backend/app/db/migrations/versions/0043_cen_carrier_qa_and_binding.py
@@ -74,7 +74,9 @@ def upgrade() -> None:
         sa.Column("passed", sa.Boolean(), nullable=False),
         sa.Column("results", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
         sa.Column("performed_by_subject", sa.String(length=255), nullable=False),
-        sa.Column("performed_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "performed_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(

--- a/backend/app/db/migrations/versions/0043_cen_carrier_qa_and_binding.py
+++ b/backend/app/db/migrations/versions/0043_cen_carrier_qa_and_binding.py
@@ -1,7 +1,7 @@
 """Add CEN data carrier binding and quality-check support.
 
 Revision ID: 0043_cen_carrier_qa_and_binding
-Revises: 0042_cen_operator_facility_entities
+Revises: 0042_cen_operator_facility
 Create Date: 2026-02-21
 """
 
@@ -11,7 +11,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "0043_cen_carrier_qa_and_binding"
-down_revision = "0042_cen_operator_facility_entities"
+down_revision = "0042_cen_operator_facility"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/db/migrations/versions/0044_cen_search_indexes.py
+++ b/backend/app/db/migrations/versions/0044_cen_search_indexes.py
@@ -1,0 +1,54 @@
+"""Add CEN-oriented search indexes for identifier lookups and cursor search.
+
+Revision ID: 0044_cen_search_indexes
+Revises: 0043_cen_carrier_qa_and_binding
+Create Date: 2026-02-21
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0044_cen_search_indexes"
+down_revision = "0043_cen_carrier_qa_and_binding"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_external_identifiers_tenant_entity_status",
+        "external_identifiers",
+        ["tenant_id", "entity_type", "status"],
+    )
+    op.create_index(
+        "ix_dpp_identifiers_tenant_external",
+        "dpp_identifiers",
+        ["tenant_id", "external_identifier_id"],
+    )
+    op.create_index(
+        "ix_dpp_identifiers_tenant_dpp",
+        "dpp_identifiers",
+        ["tenant_id", "dpp_id"],
+    )
+    op.create_index(
+        "ix_dpps_tenant_status_id",
+        "dpps",
+        ["tenant_id", "status", "id"],
+    )
+    op.create_index(
+        "ix_dpps_asset_ids_global_asset_id",
+        "dpps",
+        [sa.text("(asset_ids->>'globalAssetId')")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_dpps_asset_ids_global_asset_id", table_name="dpps")
+    op.drop_index("ix_dpps_tenant_status_id", table_name="dpps")
+    op.drop_index("ix_dpp_identifiers_tenant_dpp", table_name="dpp_identifiers")
+    op.drop_index("ix_dpp_identifiers_tenant_external", table_name="dpp_identifiers")
+    op.drop_index(
+        "ix_external_identifiers_tenant_entity_status",
+        table_name="external_identifiers",
+    )

--- a/backend/app/db/migrations/versions/0044_cen_search_indexes.py
+++ b/backend/app/db/migrations/versions/0044_cen_search_indexes.py
@@ -22,6 +22,16 @@ def upgrade() -> None:
         ["tenant_id", "entity_type", "status"],
     )
     op.create_index(
+        "ix_external_identifiers_tenant_scheme_canonical",
+        "external_identifiers",
+        ["tenant_id", "scheme_code", "value_canonical"],
+    )
+    op.create_index(
+        "ix_external_identifiers_tenant_value_raw",
+        "external_identifiers",
+        ["tenant_id", "value_raw"],
+    )
+    op.create_index(
         "ix_dpp_identifiers_tenant_external",
         "dpp_identifiers",
         ["tenant_id", "external_identifier_id"],
@@ -48,6 +58,14 @@ def downgrade() -> None:
     op.drop_index("ix_dpps_tenant_status_id", table_name="dpps")
     op.drop_index("ix_dpp_identifiers_tenant_dpp", table_name="dpp_identifiers")
     op.drop_index("ix_dpp_identifiers_tenant_external", table_name="dpp_identifiers")
+    op.drop_index(
+        "ix_external_identifiers_tenant_value_raw",
+        table_name="external_identifiers",
+    )
+    op.drop_index(
+        "ix_external_identifiers_tenant_scheme_canonical",
+        table_name="external_identifiers",
+    )
     op.drop_index(
         "ix_external_identifiers_tenant_entity_status",
         table_name="external_identifiers",

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -233,6 +233,30 @@ class DataCarrierArtifactType(str, PyEnum):
     CSV = "csv"
 
 
+class IdentifierEntityType(str, PyEnum):
+    """Entity type covered by CEN identifier governance."""
+
+    PRODUCT = "product"
+    OPERATOR = "operator"
+    FACILITY = "facility"
+
+
+class IdentifierIssuanceModel(str, PyEnum):
+    """Issuance model for identifier schemes."""
+
+    ISSUING_AGENCY = "issuing_agency"
+    SELF_ISSUED = "self_issued"
+    HYBRID = "hybrid"
+
+
+class ExternalIdentifierStatus(str, PyEnum):
+    """Lifecycle status for canonicalized external identifiers."""
+
+    ACTIVE = "active"
+    DEPRECATED = "deprecated"
+    WITHDRAWN = "withdrawn"
+
+
 class OPCUAAuthType(str, PyEnum):
     """Authentication method for OPC UA source connections."""
 
@@ -2298,6 +2322,262 @@ class ResolverLink(TenantScopedMixin, Base):
 
 
 # =============================================================================
+# Identifier Governance Models (CEN prEN 18219)
+# =============================================================================
+
+
+class EconomicOperator(TenantScopedMixin, Base):
+    """Lean tenant-scoped economic operator entity."""
+
+    __tablename__ = "economic_operators"
+
+    id: Mapped[UUID] = mapped_column(
+        primary_key=True,
+        server_default=func.uuid_generate_v7(),
+    )
+    legal_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    country: Mapped[str | None] = mapped_column(String(8), nullable=True)
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        default=dict,
+        nullable=False,
+    )
+    created_by_subject: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_economic_operators_tenant_name", "tenant_id", "legal_name"),
+        Index("ix_economic_operators_country", "country"),
+    )
+
+
+class Facility(TenantScopedMixin, Base):
+    """Lean tenant-scoped facility entity linked to an operator."""
+
+    __tablename__ = "facilities"
+
+    id: Mapped[UUID] = mapped_column(
+        primary_key=True,
+        server_default=func.uuid_generate_v7(),
+    )
+    operator_id: Mapped[UUID] = mapped_column(
+        ForeignKey("economic_operators.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    facility_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    address: Mapped[dict[str, Any]] = mapped_column(JSONB, default=dict, nullable=False)
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        default=dict,
+        nullable=False,
+    )
+    created_by_subject: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_facilities_operator", "operator_id"),
+        Index("ix_facilities_tenant_name", "tenant_id", "facility_name"),
+    )
+
+
+class IdentifierScheme(Base):
+    """Catalog of supported identifier schemes and canonicalization rules."""
+
+    __tablename__ = "identifier_schemes"
+
+    id: Mapped[UUID] = mapped_column(
+        primary_key=True,
+        server_default=func.uuid_generate_v7(),
+    )
+    code: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    entity_type: Mapped[IdentifierEntityType] = mapped_column(
+        Enum(IdentifierEntityType, values_callable=lambda e: [m.value for m in e]),
+        nullable=False,
+    )
+    issuance_model: Mapped[IdentifierIssuanceModel] = mapped_column(
+        Enum(IdentifierIssuanceModel, values_callable=lambda e: [m.value for m in e]),
+        nullable=False,
+        default=IdentifierIssuanceModel.SELF_ISSUED,
+    )
+    canonicalization_rules: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        default=dict,
+        nullable=False,
+    )
+    validation_rules: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        default=dict,
+        nullable=False,
+    )
+    openness_metadata: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        default=dict,
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_identifier_schemes_entity_type", "entity_type"),
+        Index("ix_identifier_schemes_issuance_model", "issuance_model"),
+    )
+
+
+class ExternalIdentifier(TenantScopedMixin, Base):
+    """Canonicalized identifier registry used across DPP, operators, and facilities."""
+
+    __tablename__ = "external_identifiers"
+
+    id: Mapped[UUID] = mapped_column(
+        primary_key=True,
+        server_default=func.uuid_generate_v7(),
+    )
+    entity_type: Mapped[IdentifierEntityType] = mapped_column(
+        Enum(IdentifierEntityType, values_callable=lambda e: [m.value for m in e]),
+        nullable=False,
+    )
+    scheme_code: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("identifier_schemes.code", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    value_raw: Mapped[str] = mapped_column(Text, nullable=False)
+    value_canonical: Mapped[str] = mapped_column(Text, nullable=False)
+    granularity: Mapped[DataCarrierIdentityLevel | None] = mapped_column(
+        Enum(DataCarrierIdentityLevel, values_callable=lambda e: [m.value for m in e]),
+        nullable=True,
+    )
+    status: Mapped[ExternalIdentifierStatus] = mapped_column(
+        Enum(ExternalIdentifierStatus, values_callable=lambda e: [m.value for m in e]),
+        nullable=False,
+        default=ExternalIdentifierStatus.ACTIVE,
+    )
+    replaced_by_identifier_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("external_identifiers.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    issued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    deprecates_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_by_subject: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("scheme_code", "value_canonical", name="uq_external_identifiers_scheme_value"),
+        Index("ix_external_identifiers_entity_type", "entity_type"),
+        Index("ix_external_identifiers_status", "status"),
+    )
+
+
+class DPPIdentifier(TenantScopedMixin, Base):
+    """Link table between DPPs and canonical identifiers."""
+
+    __tablename__ = "dpp_identifiers"
+
+    id: Mapped[UUID] = mapped_column(
+        primary_key=True,
+        server_default=func.uuid_generate_v7(),
+    )
+    dpp_id: Mapped[UUID] = mapped_column(
+        ForeignKey("dpps.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    external_identifier_id: Mapped[UUID] = mapped_column(
+        ForeignKey("external_identifiers.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("dpp_id", "external_identifier_id", name="uq_dpp_identifier_link"),
+        Index("ix_dpp_identifiers_dpp", "dpp_id"),
+        Index("ix_dpp_identifiers_external_identifier", "external_identifier_id"),
+    )
+
+
+class OperatorIdentifier(TenantScopedMixin, Base):
+    """Link table between operators and canonical identifiers."""
+
+    __tablename__ = "operator_identifiers"
+
+    id: Mapped[UUID] = mapped_column(
+        primary_key=True,
+        server_default=func.uuid_generate_v7(),
+    )
+    operator_id: Mapped[UUID] = mapped_column(
+        ForeignKey("economic_operators.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    external_identifier_id: Mapped[UUID] = mapped_column(
+        ForeignKey("external_identifiers.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("operator_id", "external_identifier_id", name="uq_operator_identifier_link"),
+        Index("ix_operator_identifiers_operator", "operator_id"),
+        Index("ix_operator_identifiers_external_identifier", "external_identifier_id"),
+    )
+
+
+class FacilityIdentifier(TenantScopedMixin, Base):
+    """Link table between facilities and canonical identifiers."""
+
+    __tablename__ = "facility_identifiers"
+
+    id: Mapped[UUID] = mapped_column(
+        primary_key=True,
+        server_default=func.uuid_generate_v7(),
+    )
+    facility_id: Mapped[UUID] = mapped_column(
+        ForeignKey("facilities.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    external_identifier_id: Mapped[UUID] = mapped_column(
+        ForeignKey("external_identifiers.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("facility_id", "external_identifier_id", name="uq_facility_identifier_link"),
+        Index("ix_facility_identifiers_facility", "facility_id"),
+        Index("ix_facility_identifiers_external_identifier", "external_identifier_id"),
+    )
+
+
+# =============================================================================
 # Data Carrier Models
 # =============================================================================
 
@@ -2351,10 +2631,19 @@ class DataCarrier(TenantScopedMixin, Base):
         nullable=False,
         comment="Identifier components such as gtin, serial, batch, manufacturer part id",
     )
+    external_identifier_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("external_identifiers.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     encoded_uri: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         comment="URI encoded in the carrier",
+    )
+    payload_sha256: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="SHA-256 hash of encoded payload for physical/digital binding evidence",
     )
     layout_profile: Mapped[dict[str, Any]] = mapped_column(
         JSONB,
@@ -2401,6 +2690,7 @@ class DataCarrier(TenantScopedMixin, Base):
         Index("ix_data_carriers_status", "status"),
         Index("ix_data_carriers_identifier_scheme", "identifier_scheme"),
         Index("ix_data_carriers_identifier_key", "identifier_key"),
+        Index("ix_data_carriers_external_identifier_id", "external_identifier_id"),
         Index(
             "uq_data_carriers_tenant_identifier_active_like",
             "tenant_id",
@@ -2408,6 +2698,36 @@ class DataCarrier(TenantScopedMixin, Base):
             unique=True,
             postgresql_where=text("status IN ('active','deprecated')"),
         ),
+    )
+
+
+class DataCarrierQualityCheck(TenantScopedMixin, Base):
+    """Recorded quality verification results for data carriers."""
+
+    __tablename__ = "data_carrier_quality_checks"
+
+    id: Mapped[UUID] = mapped_column(
+        primary_key=True,
+        server_default=func.uuid_generate_v7(),
+    )
+    carrier_id: Mapped[UUID] = mapped_column(
+        ForeignKey("data_carriers.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    check_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    passed: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    results: Mapped[dict[str, Any]] = mapped_column(JSONB, default=dict, nullable=False)
+    performed_by_subject: Mapped[str] = mapped_column(String(255), nullable=False)
+    performed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        Index("ix_data_carrier_quality_checks_carrier_id", "carrier_id"),
+        Index("ix_data_carrier_quality_checks_check_type", "check_type"),
+        Index("ix_data_carrier_quality_checks_performed_at", "performed_at"),
     )
 
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -2498,6 +2498,13 @@ class ExternalIdentifier(TenantScopedMixin, Base):
         ),
         Index("ix_external_identifiers_entity_type", "entity_type"),
         Index("ix_external_identifiers_status", "status"),
+        Index(
+            "ix_external_identifiers_tenant_scheme_canonical",
+            "tenant_id",
+            "scheme_code",
+            "value_canonical",
+        ),
+        Index("ix_external_identifiers_tenant_value_raw", "tenant_id", "value_raw"),
     )
 
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -2493,7 +2493,9 @@ class ExternalIdentifier(TenantScopedMixin, Base):
     )
 
     __table_args__ = (
-        UniqueConstraint("scheme_code", "value_canonical", name="uq_external_identifiers_scheme_value"),
+        UniqueConstraint(
+            "scheme_code", "value_canonical", name="uq_external_identifiers_scheme_value"
+        ),
         Index("ix_external_identifiers_entity_type", "entity_type"),
         Index("ix_external_identifiers_status", "status"),
     )
@@ -2545,7 +2547,9 @@ class OperatorIdentifier(TenantScopedMixin, Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     __table_args__ = (
-        UniqueConstraint("operator_id", "external_identifier_id", name="uq_operator_identifier_link"),
+        UniqueConstraint(
+            "operator_id", "external_identifier_id", name="uq_operator_identifier_link"
+        ),
         Index("ix_operator_identifiers_operator", "operator_id"),
         Index("ix_operator_identifiers_external_identifier", "external_identifier_id"),
     )
@@ -2571,7 +2575,9 @@ class FacilityIdentifier(TenantScopedMixin, Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     __table_args__ = (
-        UniqueConstraint("facility_id", "external_identifier_id", name="uq_facility_identifier_link"),
+        UniqueConstraint(
+            "facility_id", "external_identifier_id", name="uq_facility_identifier_link"
+        ),
         Index("ix_facility_identifiers_facility", "facility_id"),
         Index("ix_facility_identifiers_external_identifier", "external_identifier_id"),
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,8 @@ from app.core.security.abac import close_opa_client
 from app.db.session import close_db, get_db_session, init_db
 from app.modules.activity.router import router as activity_router
 from app.modules.audit.router import router as audit_router
+from app.modules.cen_api.public_router import router as public_cen_router
+from app.modules.cen_api.router import router as cen_api_router
 from app.modules.cirpass.public_router import router as public_cirpass_router
 from app.modules.compliance.router import router as compliance_router
 from app.modules.connectors.router import router as connectors_router
@@ -33,6 +35,7 @@ from app.modules.dpps.router import router as dpps_router
 from app.modules.epcis.public_router import router as public_epcis_router
 from app.modules.epcis.router import router as epcis_router
 from app.modules.export.router import router as export_router
+from app.modules.identifiers.router import router as identifiers_router
 from app.modules.lab.router import router as lab_router
 from app.modules.lca.router import router as lca_router
 from app.modules.masters.router import router as masters_router
@@ -258,6 +261,12 @@ window.onload = function() {{
         prefix=f"{settings.api_v1_prefix}/public/smt",
         tags=["Public SMT Editor"],
     )
+    if settings.cen_dpp_enabled:
+        app.include_router(
+            public_cen_router,
+            prefix=f"{settings.api_v1_prefix}/public",
+            tags=["Public CEN API"],
+        )
     app.include_router(
         lab_router,
         prefix=f"{settings.api_v1_prefix}/lab",
@@ -333,6 +342,17 @@ window.onload = function() {{
         prefix=f"{tenant_prefix}/data-carriers",
         tags=["Data Carriers"],
     )
+    if settings.cen_dpp_enabled:
+        app.include_router(
+            identifiers_router,
+            prefix=f"{tenant_prefix}/identifiers",
+            tags=["Identifiers"],
+        )
+        app.include_router(
+            cen_api_router,
+            prefix=f"{tenant_prefix}/cen",
+            tags=["CEN prEN 18222"],
+        )
     app.include_router(
         settings_router,
         prefix=f"{settings.api_v1_prefix}/admin/settings",

--- a/backend/app/modules/cen_api/__init__.py
+++ b/backend/app/modules/cen_api/__init__.py
@@ -1,0 +1,2 @@
+"""CEN API facade module."""
+

--- a/backend/app/modules/cen_api/__init__.py
+++ b/backend/app/modules/cen_api/__init__.py
@@ -1,2 +1,1 @@
 """CEN API facade module."""
-

--- a/backend/app/modules/cen_api/public_router.py
+++ b/backend/app/modules/cen_api/public_router.py
@@ -196,6 +196,10 @@ async def public_search_dpps(
             published_only=True,
         )
     except CENAPIError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
-    items = [await _to_public_response(service=service, dpp_service=dpp_service, dpp=dpp) for dpp in dpps]
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
+    items = [
+        await _to_public_response(service=service, dpp_service=dpp_service, dpp=dpp) for dpp in dpps
+    ]
     return CENDPPSearchResponse(items=items, paging=CENPaging(cursor=next_cursor))

--- a/backend/app/modules/cen_api/public_router.py
+++ b/backend/app/modules/cen_api/public_router.py
@@ -1,0 +1,201 @@
+"""Public (unauthenticated) CEN prEN 18222 read/search facade."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query, Response, status
+from sqlalchemy import select
+
+from app.db.models import DPP, DPPStatus, Tenant, TenantStatus
+from app.db.session import DbSession
+from app.modules.cen_api.schemas import CENDPPSearchResponse, CENPaging, CENPublicDPPResponse
+from app.modules.cen_api.service import CENAPIError, CENAPINotFoundError, CENAPIService
+from app.modules.dpps.service import DPPService
+from app.standards.cen_pren import get_cen_profiles, standards_profile_header
+
+router = APIRouter()
+
+_SENSITIVE_PUBLIC_KEYS = frozenset(
+    {
+        "dppid",
+        "aasid",
+        "serialnumber",
+        "batchid",
+        "globalassetid",
+        "payload",
+        "readpoint",
+        "bizlocation",
+        "ownersubject",
+        "usersubject",
+        "createdbysubject",
+        "email",
+    }
+)
+
+_SENSITIVE_ASSET_ID_KEYS = frozenset({"serialnumber", "batchid", "globalassetid", "dppid", "aasid"})
+
+
+def _set_standards_header(response: Response) -> None:
+    response.headers["X-Standards-Profile"] = standards_profile_header(get_cen_profiles())
+
+
+async def _resolve_tenant(db: DbSession, tenant_slug: str) -> Tenant:
+    result = await db.execute(
+        select(Tenant).where(
+            Tenant.slug == tenant_slug.strip().lower(),
+            Tenant.status == TenantStatus.ACTIVE,
+        )
+    )
+    tenant = result.scalar_one_or_none()
+    if tenant is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    return tenant
+
+
+def _normalize_public_key(key: str) -> str:
+    return "".join(ch for ch in key.lower() if ch.isalnum())
+
+
+def _is_sensitive_public_key(key: str) -> bool:
+    return _normalize_public_key(key) in _SENSITIVE_PUBLIC_KEYS
+
+
+def _is_sensitive_asset_id_key(key: str) -> bool:
+    return _normalize_public_key(key) in _SENSITIVE_ASSET_ID_KEYS
+
+
+def _is_aas_element(node: dict[str, Any]) -> bool:
+    return "modelType" in node or "idShort" in node or "qualifiers" in node
+
+
+def _element_is_public(element: dict[str, Any]) -> bool:
+    qualifiers = element.get("qualifiers", [])
+    for qualifier in qualifiers:
+        if qualifier.get("type") == "Confidentiality":
+            return str(qualifier.get("value", "public")).lower() == "public"
+    return True
+
+
+def _filter_public_node(node: Any) -> Any:
+    if isinstance(node, list):
+        output: list[Any] = []
+        for item in node:
+            filtered = _filter_public_node(item)
+            if filtered is None:
+                continue
+            output.append(filtered)
+        return output
+
+    if isinstance(node, dict):
+        if _is_aas_element(node) and not _element_is_public(node):
+            return None
+        filtered_dict: dict[str, Any] = {}
+        for key, value in node.items():
+            if _is_sensitive_public_key(key):
+                continue
+            filtered_value = _filter_public_node(value)
+            if filtered_value is None and isinstance(value, dict) and _is_aas_element(value):
+                continue
+            filtered_dict[key] = filtered_value
+        return filtered_dict
+
+    return node
+
+
+def _filter_public_aas_environment(aas_env: dict[str, Any]) -> dict[str, Any]:
+    projected = _filter_public_node(copy.deepcopy(aas_env))
+    if isinstance(projected, dict):
+        return projected
+    return {"submodels": []}
+
+
+def _filter_public_asset_ids(asset_ids: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in asset_ids.items() if not _is_sensitive_asset_id_key(key)}
+
+
+async def _to_public_response(
+    *,
+    service: CENAPIService,
+    dpp_service: DPPService,
+    dpp: DPP,
+) -> CENPublicDPPResponse:
+    revision = await dpp_service.get_published_revision(dpp_id=dpp.id, tenant_id=dpp.tenant_id)
+    aas_env = None
+    if revision is not None:
+        decrypted = await dpp_service.get_revision_aas_for_reader(revision)
+        if isinstance(decrypted, dict):
+            aas_env = _filter_public_aas_environment(decrypted)
+
+    cen_payload = await service.to_cen_dpp_response(dpp)
+    return CENPublicDPPResponse(
+        id=dpp.id,
+        status=dpp.status.value,
+        asset_ids=_filter_public_asset_ids(dpp.asset_ids or {}),
+        created_at=dpp.created_at,
+        updated_at=dpp.updated_at,
+        current_revision_no=revision.revision_no if revision else None,
+        aas_environment=aas_env,
+        digest_sha256=revision.digest_sha256 if revision else None,
+        product_identifier=cen_payload.product_identifier,
+        identifier_scheme=cen_payload.identifier_scheme,
+        granularity=cen_payload.granularity,
+    )
+
+
+@router.get(
+    "/{tenant_slug}/cen/dpps/{dpp_id:uuid}",
+    response_model=CENPublicDPPResponse,
+    operation_id="PublicReadDPPById",
+)
+async def public_read_dpp_by_id(
+    tenant_slug: str,
+    dpp_id: UUID,
+    db: DbSession,
+    response: Response,
+) -> CENPublicDPPResponse:
+    _set_standards_header(response)
+    tenant = await _resolve_tenant(db, tenant_slug)
+    service = CENAPIService(db)
+    dpp_service = DPPService(db)
+    try:
+        dpp = await service.get_published_dpp(tenant_id=tenant.id, dpp_id=dpp_id)
+    except CENAPINotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found") from exc
+    return await _to_public_response(service=service, dpp_service=dpp_service, dpp=dpp)
+
+
+@router.get(
+    "/{tenant_slug}/cen/dpps",
+    response_model=CENDPPSearchResponse,
+    operation_id="PublicSearchDPPs",
+)
+async def public_search_dpps(
+    tenant_slug: str,
+    db: DbSession,
+    response: Response,
+    limit: int = Query(default=50, ge=1, le=100),
+    cursor: str | None = Query(default=None),
+    identifier: str | None = Query(default=None),
+    scheme: str | None = Query(default=None),
+) -> CENDPPSearchResponse:
+    _set_standards_header(response)
+    tenant = await _resolve_tenant(db, tenant_slug)
+    service = CENAPIService(db)
+    dpp_service = DPPService(db)
+    try:
+        dpps, next_cursor = await service.search_dpps(
+            tenant_id=tenant.id,
+            limit=limit,
+            cursor=cursor,
+            identifier=identifier,
+            scheme=scheme,
+            status=DPPStatus.PUBLISHED.value,
+            published_only=True,
+        )
+    except CENAPIError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    items = [await _to_public_response(service=service, dpp_service=dpp_service, dpp=dpp) for dpp in dpps]
+    return CENDPPSearchResponse(items=items, paging=CENPaging(cursor=next_cursor))

--- a/backend/app/modules/cen_api/router.py
+++ b/backend/app/modules/cen_api/router.py
@@ -93,7 +93,9 @@ async def create_dpp(
             required_specific_asset_ids=body.required_specific_asset_ids,
         )
     except CENAPIError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
     await db.commit()
     await db.refresh(dpp)
     return await service.to_cen_dpp_response(dpp)
@@ -147,14 +149,18 @@ async def search_dpps(
             is_tenant_admin=tenant.is_tenant_admin,
         )
     except CENAPIError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
     return CENDPPSearchResponse(
         items=[await service.to_cen_dpp_response(dpp) for dpp in dpps],
         paging=CENPaging(cursor=next_cursor),
     )
 
 
-@router.get("/dpps/by-identifier", response_model=CENDPPResponse, operation_id="ReadDPPByIdentifier")
+@router.get(
+    "/dpps/by-identifier", response_model=CENDPPResponse, operation_id="ReadDPPByIdentifier"
+)
 async def read_dpp_by_identifier(
     db: DbSession,
     tenant: TenantPublisher,
@@ -181,7 +187,9 @@ async def read_dpp_by_identifier(
     except CENAPINotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     except CENAPIError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
     await _require_dpp_access(db=db, tenant=tenant, dpp_id=dpp.id, action="read")
     return await service.to_cen_dpp_response(dpp)
 
@@ -210,7 +218,9 @@ async def update_dpp(
     except CENAPIConflictError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
     except CENAPIError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
     await db.commit()
     await db.refresh(dpp)
     return await service.to_cen_dpp_response(dpp)
@@ -237,7 +247,9 @@ async def archive_dpp(
     return await service.to_cen_dpp_response(dpp)
 
 
-@router.post("/dpps/{dpp_id:uuid}/publish", response_model=CENDPPResponse, operation_id="PublishDPP")
+@router.post(
+    "/dpps/{dpp_id:uuid}/publish", response_model=CENDPPResponse, operation_id="PublishDPP"
+)
 async def publish_dpp(
     dpp_id: UUID,
     db: DbSession,
@@ -340,7 +352,9 @@ async def register_identifier(
             facility_id=body.facility_id,
         )
     except CENAPIError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
     await db.commit()
     await db.refresh(identifier)
     return CENExternalIdentifierResponse(**service.identifiers_to_response(identifier))
@@ -375,7 +389,9 @@ async def supersede_identifier(
     except CENAPINotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     except CENAPIError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
     await db.commit()
     await db.refresh(identifier)
     return CENExternalIdentifierResponse(**service.identifiers_to_response(identifier))
@@ -402,11 +418,15 @@ async def sync_registry_for_dpp(
             created_by=tenant.user.sub,
         )
     except CENFeatureDisabledError as exc:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
+        ) from exc
     except CENAPINotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     except CENAPIError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
     await db.commit()
     return CENSyncResponse(dpp_id=dpp_id, synced=True, target="registry")
 
@@ -432,11 +452,14 @@ async def sync_resolver_for_dpp(
             created_by=tenant.user.sub,
         )
     except CENFeatureDisabledError as exc:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
+        ) from exc
     except CENAPINotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     except CENAPIError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
     await db.commit()
     return CENSyncResponse(dpp_id=dpp_id, synced=True, target="resolver")
-

--- a/backend/app/modules/cen_api/router.py
+++ b/backend/app/modules/cen_api/router.py
@@ -1,0 +1,442 @@
+"""Tenant-scoped CEN prEN 18222 API facade routes."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query, Response, status
+
+from app.core.security import require_access
+from app.core.security.resource_context import build_dpp_resource_context
+from app.core.tenancy import TenantPublisher
+from app.db.models import IdentifierEntityType
+from app.db.session import DbSession
+from app.modules.cen_api.schemas import (
+    CENCreateDPPRequest,
+    CENDPPResponse,
+    CENDPPSearchResponse,
+    CENExternalIdentifierResponse,
+    CENPaging,
+    CENRegisterIdentifierRequest,
+    CENSupersedeIdentifierRequest,
+    CENSyncResponse,
+    CENUpdateDPPRequest,
+    CENValidateIdentifierRequest,
+    CENValidateIdentifierResponse,
+)
+from app.modules.cen_api.service import (
+    CENAPIConflictError,
+    CENAPIError,
+    CENAPINotFoundError,
+    CENAPIService,
+    CENFeatureDisabledError,
+)
+from app.modules.dpps.service import DPPService
+from app.standards.cen_pren import get_cen_profiles, standards_profile_header
+
+router = APIRouter()
+
+
+def _set_standards_header(response: Response) -> None:
+    response.headers["X-Standards-Profile"] = standards_profile_header(get_cen_profiles())
+
+
+async def _require_dpp_access(
+    *,
+    db: DbSession,
+    tenant: TenantPublisher,
+    dpp_id: UUID,
+    action: str,
+) -> object:
+    dpp_service = DPPService(db)
+    dpp = await dpp_service.get_dpp(dpp_id=dpp_id, tenant_id=tenant.tenant_id)
+    if dpp is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="DPP not found")
+    shared_with_current_user = await dpp_service.is_resource_shared_with_user(
+        tenant_id=tenant.tenant_id,
+        resource_type="dpp",
+        resource_id=dpp.id,
+        user_subject=tenant.user.sub,
+    )
+    await require_access(
+        tenant.user,
+        action,
+        build_dpp_resource_context(dpp, shared_with_current_user=shared_with_current_user),
+        tenant=tenant,
+    )
+    return dpp
+
+
+@router.post(
+    "/dpps",
+    response_model=CENDPPResponse,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="CreateDPP",
+)
+async def create_dpp(
+    body: CENCreateDPPRequest,
+    db: DbSession,
+    tenant: TenantPublisher,
+    response: Response,
+) -> CENDPPResponse:
+    _set_standards_header(response)
+    await require_access(tenant.user, "create", {"type": "dpp"}, tenant=tenant)
+    service = CENAPIService(db)
+    try:
+        dpp = await service.create_dpp(
+            tenant_id=tenant.tenant_id,
+            tenant_slug=tenant.tenant_slug,
+            owner_subject=tenant.user.sub,
+            asset_ids=body.asset_ids,
+            selected_templates=body.selected_templates,
+            initial_data=body.initial_data,
+            required_specific_asset_ids=body.required_specific_asset_ids,
+        )
+    except CENAPIError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    await db.commit()
+    await db.refresh(dpp)
+    return await service.to_cen_dpp_response(dpp)
+
+
+@router.get("/dpps/{dpp_id:uuid}", response_model=CENDPPResponse, operation_id="ReadDPPById")
+async def read_dpp_by_id(
+    dpp_id: UUID,
+    db: DbSession,
+    tenant: TenantPublisher,
+    response: Response,
+) -> CENDPPResponse:
+    _set_standards_header(response)
+    await _require_dpp_access(db=db, tenant=tenant, dpp_id=dpp_id, action="read")
+    service = CENAPIService(db)
+    try:
+        dpp = await service.get_dpp(tenant_id=tenant.tenant_id, dpp_id=dpp_id)
+    except CENAPINotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return await service.to_cen_dpp_response(dpp)
+
+
+@router.get("/dpps", response_model=CENDPPSearchResponse, operation_id="SearchDPPs")
+async def search_dpps(
+    db: DbSession,
+    tenant: TenantPublisher,
+    response: Response,
+    limit: int = Query(default=50, ge=1, le=100),
+    cursor: str | None = Query(default=None),
+    identifier: str | None = Query(default=None),
+    scheme: str | None = Query(default=None),
+    status_filter: str | None = Query(default=None, alias="status"),
+) -> CENDPPSearchResponse:
+    _set_standards_header(response)
+    await require_access(
+        tenant.user,
+        "list",
+        {"type": "dpp", "owner_subject": tenant.user.sub},
+        tenant=tenant,
+    )
+    service = CENAPIService(db)
+    try:
+        dpps, next_cursor = await service.search_dpps(
+            tenant_id=tenant.tenant_id,
+            limit=limit,
+            cursor=cursor,
+            identifier=identifier,
+            scheme=scheme,
+            status=status_filter,
+            user_subject=tenant.user.sub,
+            is_tenant_admin=tenant.is_tenant_admin,
+        )
+    except CENAPIError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    return CENDPPSearchResponse(
+        items=[await service.to_cen_dpp_response(dpp) for dpp in dpps],
+        paging=CENPaging(cursor=next_cursor),
+    )
+
+
+@router.get("/dpps/by-identifier", response_model=CENDPPResponse, operation_id="ReadDPPByIdentifier")
+async def read_dpp_by_identifier(
+    db: DbSession,
+    tenant: TenantPublisher,
+    response: Response,
+    identifier: str = Query(..., min_length=1),
+    scheme: str = Query(..., min_length=1),
+) -> CENDPPResponse:
+    _set_standards_header(response)
+    await require_access(
+        tenant.user,
+        "read",
+        {"type": "dpp", "owner_subject": tenant.user.sub},
+        tenant=tenant,
+    )
+    service = CENAPIService(db)
+    try:
+        dpp = await service.read_dpp_by_identifier(
+            tenant_id=tenant.tenant_id,
+            scheme=scheme,
+            identifier=identifier,
+            user_subject=tenant.user.sub,
+            is_tenant_admin=tenant.is_tenant_admin,
+        )
+    except CENAPINotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except CENAPIError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    await _require_dpp_access(db=db, tenant=tenant, dpp_id=dpp.id, action="read")
+    return await service.to_cen_dpp_response(dpp)
+
+
+@router.patch("/dpps/{dpp_id:uuid}", response_model=CENDPPResponse, operation_id="UpdateDPP")
+async def update_dpp(
+    dpp_id: UUID,
+    body: CENUpdateDPPRequest,
+    db: DbSession,
+    tenant: TenantPublisher,
+    response: Response,
+) -> CENDPPResponse:
+    _set_standards_header(response)
+    await _require_dpp_access(db=db, tenant=tenant, dpp_id=dpp_id, action="update")
+    service = CENAPIService(db)
+    try:
+        dpp = await service.update_dpp(
+            tenant_id=tenant.tenant_id,
+            dpp_id=dpp_id,
+            updated_by=tenant.user.sub,
+            asset_ids_patch=body.asset_ids,
+            visibility_scope=body.visibility_scope,
+        )
+    except CENAPINotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except CENAPIConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except CENAPIError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    await db.commit()
+    await db.refresh(dpp)
+    return await service.to_cen_dpp_response(dpp)
+
+
+@router.delete("/dpps/{dpp_id:uuid}", response_model=CENDPPResponse, operation_id="ArchiveDPP")
+async def archive_dpp(
+    dpp_id: UUID,
+    db: DbSession,
+    tenant: TenantPublisher,
+    response: Response,
+) -> CENDPPResponse:
+    _set_standards_header(response)
+    await _require_dpp_access(db=db, tenant=tenant, dpp_id=dpp_id, action="archive")
+    service = CENAPIService(db)
+    try:
+        dpp = await service.archive_dpp(tenant_id=tenant.tenant_id, dpp_id=dpp_id)
+    except CENAPINotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except CENAPIConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    await db.commit()
+    await db.refresh(dpp)
+    return await service.to_cen_dpp_response(dpp)
+
+
+@router.post("/dpps/{dpp_id:uuid}/publish", response_model=CENDPPResponse, operation_id="PublishDPP")
+async def publish_dpp(
+    dpp_id: UUID,
+    db: DbSession,
+    tenant: TenantPublisher,
+    response: Response,
+) -> CENDPPResponse:
+    _set_standards_header(response)
+    await _require_dpp_access(db=db, tenant=tenant, dpp_id=dpp_id, action="publish")
+    service = CENAPIService(db)
+    try:
+        dpp = await service.publish_dpp(
+            tenant_id=tenant.tenant_id,
+            dpp_id=dpp_id,
+            published_by=tenant.user.sub,
+        )
+    except CENAPINotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except CENAPIConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    await db.commit()
+    await db.refresh(dpp)
+    return await service.to_cen_dpp_response(dpp)
+
+
+@router.post(
+    "/identifiers/validate",
+    response_model=CENValidateIdentifierResponse,
+    operation_id="ValidateIdentifier",
+)
+async def validate_identifier(
+    body: CENValidateIdentifierRequest,
+    db: DbSession,
+    tenant: TenantPublisher,
+    response: Response,
+) -> CENValidateIdentifierResponse:
+    _set_standards_header(response)
+    await require_access(
+        tenant.user,
+        "create",
+        {"type": "identifier", "owner_subject": tenant.user.sub},
+        tenant=tenant,
+    )
+    service = CENAPIService(db)
+    try:
+        canonical = await service.validate_identifier(
+            entity_type=IdentifierEntityType(body.entity_type.value),
+            scheme_code=body.scheme_code,
+            value_raw=body.value_raw,
+            granularity=body.granularity,
+        )
+    except CENAPIError as exc:
+        return CENValidateIdentifierResponse(
+            valid=False,
+            entity_type=body.entity_type,
+            scheme_code=body.scheme_code,
+            value_raw=body.value_raw,
+            granularity=body.granularity,
+            errors=[str(exc)],
+        )
+    return CENValidateIdentifierResponse(
+        valid=True,
+        entity_type=body.entity_type,
+        scheme_code=body.scheme_code,
+        value_raw=body.value_raw,
+        value_canonical=canonical,
+        granularity=body.granularity,
+    )
+
+
+@router.post(
+    "/identifiers",
+    response_model=CENExternalIdentifierResponse,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="RegisterIdentifier",
+)
+async def register_identifier(
+    body: CENRegisterIdentifierRequest,
+    db: DbSession,
+    tenant: TenantPublisher,
+    response: Response,
+) -> CENExternalIdentifierResponse:
+    _set_standards_header(response)
+    await require_access(
+        tenant.user,
+        "create",
+        {"type": "identifier", "owner_subject": tenant.user.sub},
+        tenant=tenant,
+    )
+    service = CENAPIService(db)
+    try:
+        identifier = await service.register_identifier(
+            tenant_id=tenant.tenant_id,
+            created_by=tenant.user.sub,
+            entity_type=IdentifierEntityType(body.entity_type.value),
+            scheme_code=body.scheme_code,
+            value_raw=body.value_raw,
+            granularity=body.granularity,
+            dpp_id=body.dpp_id,
+            operator_id=body.operator_id,
+            facility_id=body.facility_id,
+        )
+    except CENAPIError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    await db.commit()
+    await db.refresh(identifier)
+    return CENExternalIdentifierResponse(**service.identifiers_to_response(identifier))
+
+
+@router.post(
+    "/identifiers/{identifier_id:uuid}/supersede",
+    response_model=CENExternalIdentifierResponse,
+    operation_id="SupersedeIdentifier",
+)
+async def supersede_identifier(
+    identifier_id: UUID,
+    body: CENSupersedeIdentifierRequest,
+    db: DbSession,
+    tenant: TenantPublisher,
+    response: Response,
+) -> CENExternalIdentifierResponse:
+    _set_standards_header(response)
+    await require_access(
+        tenant.user,
+        "update",
+        {"type": "identifier", "owner_subject": tenant.user.sub},
+        tenant=tenant,
+    )
+    service = CENAPIService(db)
+    try:
+        identifier = await service.supersede_identifier(
+            tenant_id=tenant.tenant_id,
+            identifier_id=identifier_id,
+            replacement_identifier_id=body.replacement_identifier_id,
+        )
+    except CENAPINotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except CENAPIError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    await db.commit()
+    await db.refresh(identifier)
+    return CENExternalIdentifierResponse(**service.identifiers_to_response(identifier))
+
+
+@router.post(
+    "/registrations/dpps/{dpp_id:uuid}",
+    response_model=CENSyncResponse,
+    operation_id="SyncRegistryForDPP",
+)
+async def sync_registry_for_dpp(
+    dpp_id: UUID,
+    db: DbSession,
+    tenant: TenantPublisher,
+    response: Response,
+) -> CENSyncResponse:
+    _set_standards_header(response)
+    await _require_dpp_access(db=db, tenant=tenant, dpp_id=dpp_id, action="publish")
+    service = CENAPIService(db)
+    try:
+        await service.sync_registry_for_dpp(
+            tenant_id=tenant.tenant_id,
+            dpp_id=dpp_id,
+            created_by=tenant.user.sub,
+        )
+    except CENFeatureDisabledError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+    except CENAPINotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except CENAPIError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    await db.commit()
+    return CENSyncResponse(dpp_id=dpp_id, synced=True, target="registry")
+
+
+@router.post(
+    "/resolutions/dpps/{dpp_id:uuid}",
+    response_model=CENSyncResponse,
+    operation_id="SyncResolverForDPP",
+)
+async def sync_resolver_for_dpp(
+    dpp_id: UUID,
+    db: DbSession,
+    tenant: TenantPublisher,
+    response: Response,
+) -> CENSyncResponse:
+    _set_standards_header(response)
+    await _require_dpp_access(db=db, tenant=tenant, dpp_id=dpp_id, action="publish")
+    service = CENAPIService(db)
+    try:
+        await service.sync_resolver_for_dpp(
+            tenant_id=tenant.tenant_id,
+            dpp_id=dpp_id,
+            created_by=tenant.user.sub,
+        )
+    except CENFeatureDisabledError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+    except CENAPINotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except CENAPIError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    await db.commit()
+    return CENSyncResponse(dpp_id=dpp_id, synced=True, target="resolver")
+

--- a/backend/app/modules/cen_api/router.py
+++ b/backend/app/modules/cen_api/router.py
@@ -153,7 +153,7 @@ async def search_dpps(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
         ) from exc
     return CENDPPSearchResponse(
-        items=[await service.to_cen_dpp_response(dpp) for dpp in dpps],
+        items=await service.get_public_dpp_responses(dpps=dpps),
         paging=CENPaging(cursor=next_cursor),
     )
 

--- a/backend/app/modules/cen_api/schemas.py
+++ b/backend/app/modules/cen_api/schemas.py
@@ -1,0 +1,143 @@
+"""Schemas for the tenant/public CEN prEN 18222 API facade."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.modules.identifiers.schemas import IdentifierEntityType, IdentifierGranularity
+
+
+class CENCreateDPPRequest(BaseModel):
+    """Create request for CEN facade DPP creation."""
+
+    asset_ids: dict[str, Any] = Field(default_factory=dict)
+    selected_templates: list[str] = Field(default_factory=lambda: ["digital-nameplate"])
+    initial_data: dict[str, Any] | None = None
+    required_specific_asset_ids: list[str] | None = None
+
+
+class CENUpdateDPPRequest(BaseModel):
+    """Partial update payload for CEN facade DPP updates."""
+
+    asset_ids: dict[str, Any] | None = None
+    visibility_scope: Literal["owner_team", "tenant"] | None = None
+
+
+class CENDPPResponse(BaseModel):
+    """Canonical CEN facade DPP payload."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: UUID
+    platform_id: UUID = Field(alias="platformId")
+    status: str
+    asset_ids: dict[str, Any]
+    product_identifier: str | None = Field(default=None, alias="productIdentifier")
+    identifier_scheme: str | None = Field(default=None, alias="identifierScheme")
+    granularity: IdentifierGranularity | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class CENPaging(BaseModel):
+    """Cursor-based paging metadata."""
+
+    cursor: str | None = None
+
+
+class CENDPPSearchResponse(BaseModel):
+    """CEN DPP search response contract."""
+
+    items: list[CENDPPResponse]
+    paging: CENPaging
+
+
+class CENValidateIdentifierRequest(BaseModel):
+    """Identifier validation request."""
+
+    entity_type: IdentifierEntityType
+    scheme_code: str = Field(min_length=1, max_length=64)
+    value_raw: str = Field(min_length=1)
+    granularity: IdentifierGranularity | None = None
+
+
+class CENValidateIdentifierResponse(BaseModel):
+    """Identifier validation output with canonicalization."""
+
+    valid: bool
+    entity_type: IdentifierEntityType
+    scheme_code: str
+    value_raw: str
+    value_canonical: str | None = None
+    granularity: IdentifierGranularity | None = None
+    errors: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class CENRegisterIdentifierRequest(BaseModel):
+    """Identifier register request."""
+
+    entity_type: IdentifierEntityType
+    scheme_code: str = Field(min_length=1, max_length=64)
+    value_raw: str = Field(min_length=1)
+    granularity: IdentifierGranularity | None = None
+    dpp_id: UUID | None = None
+    operator_id: UUID | None = None
+    facility_id: UUID | None = None
+
+
+class CENExternalIdentifierResponse(BaseModel):
+    """Canonical identifier representation for CEN facade."""
+
+    id: UUID
+    tenant_id: UUID
+    entity_type: IdentifierEntityType
+    scheme_code: str
+    value_raw: str
+    value_canonical: str
+    granularity: IdentifierGranularity | None = None
+    status: str
+    replaced_by_identifier_id: UUID | None = None
+    issued_at: datetime | None = None
+    deprecates_at: datetime | None = None
+    created_by_subject: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class CENSupersedeIdentifierRequest(BaseModel):
+    """Supersede request payload."""
+
+    replacement_identifier_id: UUID
+
+
+class CENSyncResponse(BaseModel):
+    """Deterministic sync operation result payload."""
+
+    dpp_id: UUID
+    synced: bool
+    target: Literal["registry", "resolver"]
+    detail: str | None = None
+
+
+class CENPublicDPPResponse(BaseModel):
+    """Public CEN DPP payload (published-only, filtered)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: UUID
+    status: str
+    asset_ids: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+    current_revision_no: int | None = None
+    aas_environment: dict[str, Any] | None = None
+    digest_sha256: str | None = None
+    product_identifier: str | None = Field(default=None, alias="productIdentifier")
+    identifier_scheme: str | None = Field(default=None, alias="identifierScheme")
+    granularity: IdentifierGranularity | None = None
+

--- a/backend/app/modules/cen_api/schemas.py
+++ b/backend/app/modules/cen_api/schemas.py
@@ -140,4 +140,3 @@ class CENPublicDPPResponse(BaseModel):
     product_identifier: str | None = Field(default=None, alias="productIdentifier")
     identifier_scheme: str | None = Field(default=None, alias="identifierScheme")
     granularity: IdentifierGranularity | None = None
-

--- a/backend/app/modules/cen_api/service.py
+++ b/backend/app/modules/cen_api/service.py
@@ -1,0 +1,493 @@
+"""Service layer for CEN prEN 18222 facade routes."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import Select, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import get_settings
+from app.db.models import (
+    DPP,
+    DPPIdentifier,
+    DPPStatus,
+    ExternalIdentifier,
+    ExternalIdentifierStatus,
+    IdentifierEntityType,
+    VisibilityScope,
+)
+from app.db.models import (
+    DataCarrierIdentityLevel as DBGranularity,
+)
+from app.modules.cen_api.schemas import CENDPPResponse
+from app.modules.dpps.idta_schemas import decode_cursor, encode_cursor
+from app.modules.dpps.service import DPPService
+from app.modules.identifiers.schemas import IdentifierEntityType as SchemaEntityType
+from app.modules.identifiers.schemas import IdentifierGranularity
+from app.modules.identifiers.service import IdentifierModuleService
+from app.modules.registry.service import BuiltInRegistryService
+from app.modules.resolver.service import ResolverService
+from app.standards.cen_pren.identifiers_18219 import IdentifierGovernanceError, IdentifierService
+
+_IDENTIFIER_CRITICAL_KEYS = frozenset(
+    {"manufacturerPartId", "serialNumber", "batchId", "globalAssetId", "gtin"}
+)
+
+
+class CENAPIError(ValueError):
+    """Base CEN facade error."""
+
+
+class CENAPINotFoundError(CENAPIError):
+    """Raised when a requested resource does not exist."""
+
+
+class CENAPIConflictError(CENAPIError):
+    """Raised when requested mutation conflicts with lifecycle rules."""
+
+
+class CENFeatureDisabledError(CENAPIError):
+    """Raised when dependent subsystem is disabled in config."""
+
+
+def _to_schema_entity_type(entity_type: IdentifierEntityType) -> SchemaEntityType:
+    return SchemaEntityType(entity_type.value)
+
+
+def _to_db_granularity(granularity: IdentifierGranularity | None) -> DBGranularity | None:
+    if granularity is None:
+        return None
+    return DBGranularity(granularity.value)
+
+
+def _to_schema_granularity(granularity: DBGranularity | None) -> IdentifierGranularity | None:
+    if granularity is None:
+        return None
+    return IdentifierGranularity(granularity.value)
+
+
+def _normalize_status(status: str | None) -> DPPStatus | None:
+    if status is None:
+        return None
+    normalized = status.strip().lower()
+    if not normalized:
+        return None
+    try:
+        return DPPStatus(normalized)
+    except ValueError as exc:
+        raise CENAPIError(f"Unsupported status filter '{status}'") from exc
+
+
+class CENAPIService:
+    """Adapter service mapping CEN facade operations onto existing domain services."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+        self._settings = get_settings()
+        self._dpp_service = DPPService(session)
+        self._identifier_service = IdentifierService(session)
+        self._identifier_module = IdentifierModuleService(session)
+
+    async def create_dpp(
+        self,
+        *,
+        tenant_id: UUID,
+        tenant_slug: str,
+        owner_subject: str,
+        asset_ids: dict[str, Any],
+        selected_templates: list[str],
+        initial_data: dict[str, Any] | None,
+        required_specific_asset_ids: list[str] | None,
+    ) -> DPP:
+        return await self._dpp_service.create_dpp(
+            tenant_id=tenant_id,
+            tenant_slug=tenant_slug,
+            owner_subject=owner_subject,
+            asset_ids=asset_ids,
+            selected_templates=selected_templates,
+            initial_data=initial_data,
+            required_specific_asset_ids=required_specific_asset_ids,
+        )
+
+    async def get_dpp(self, *, tenant_id: UUID, dpp_id: UUID) -> DPP:
+        dpp = await self._dpp_service.get_dpp(dpp_id=dpp_id, tenant_id=tenant_id)
+        if dpp is None:
+            raise CENAPINotFoundError("DPP not found")
+        return dpp
+
+    async def get_published_dpp(self, *, tenant_id: UUID, dpp_id: UUID) -> DPP:
+        dpp = await self.get_dpp(tenant_id=tenant_id, dpp_id=dpp_id)
+        if dpp.status != DPPStatus.PUBLISHED:
+            raise CENAPINotFoundError("DPP not found")
+        return dpp
+
+    async def search_dpps(
+        self,
+        *,
+        tenant_id: UUID,
+        limit: int,
+        cursor: str | None,
+        identifier: str | None,
+        scheme: str | None,
+        status: str | None,
+        published_only: bool = False,
+        user_subject: str | None = None,
+        is_tenant_admin: bool = False,
+    ) -> tuple[list[DPP], str | None]:
+        status_filter = DPPStatus.PUBLISHED if published_only else _normalize_status(status)
+
+        stmt: Select[tuple[UUID]] = select(DPP.id).where(DPP.tenant_id == tenant_id)
+        if status_filter is not None:
+            stmt = stmt.where(DPP.status == status_filter)
+        if cursor:
+            stmt = stmt.where(DPP.id > decode_cursor(cursor))
+
+        if user_subject is not None and not published_only and not is_tenant_admin:
+            shared_ids = await self._dpp_service.get_shared_resource_ids(
+                tenant_id=tenant_id,
+                resource_type="dpp",
+                user_subject=user_subject,
+            )
+            access_conditions = [
+                DPP.owner_subject == user_subject,
+                DPP.visibility_scope == VisibilityScope.TENANT,
+            ]
+            if shared_ids:
+                access_conditions.append(DPP.id.in_(shared_ids))
+            stmt = stmt.where(or_(*access_conditions))
+
+        scheme_code = scheme.strip().lower() if scheme else None
+        identifier_value = identifier.strip() if identifier else None
+        if scheme_code is not None or identifier_value is not None:
+            stmt = (
+                stmt.join(DPPIdentifier, DPPIdentifier.dpp_id == DPP.id)
+                .join(ExternalIdentifier, ExternalIdentifier.id == DPPIdentifier.external_identifier_id)
+                .where(
+                    ExternalIdentifier.entity_type == IdentifierEntityType.PRODUCT,
+                    ExternalIdentifier.status == ExternalIdentifierStatus.ACTIVE,
+                )
+            )
+            if scheme_code is not None:
+                stmt = stmt.where(ExternalIdentifier.scheme_code == scheme_code)
+            if identifier_value is not None:
+                if scheme_code is not None:
+                    try:
+                        canonical = self._identifier_service.canonicalize(
+                            scheme_code=scheme_code,
+                            value_raw=identifier_value,
+                        )
+                    except IdentifierGovernanceError as exc:
+                        raise CENAPIError(str(exc)) from exc
+                    stmt = stmt.where(ExternalIdentifier.value_canonical == canonical)
+                else:
+                    stmt = stmt.where(
+                        or_(
+                            ExternalIdentifier.value_canonical == identifier_value,
+                            ExternalIdentifier.value_raw == identifier_value,
+                        )
+                    )
+
+        stmt = stmt.distinct().order_by(DPP.id).limit(limit + 1)
+        result = await self._session.execute(stmt)
+        ids = list(result.scalars().all())
+        has_more = len(ids) > limit
+        page_ids = ids[:limit]
+        if not page_ids:
+            return [], None
+
+        rows = await self._session.execute(
+            select(DPP)
+            .where(DPP.tenant_id == tenant_id, DPP.id.in_(page_ids))
+            .order_by(DPP.id)
+        )
+        dpps = list(rows.scalars().all())
+        next_cursor = encode_cursor(page_ids[-1]) if has_more else None
+        return dpps, next_cursor
+
+    async def read_dpp_by_identifier(
+        self,
+        *,
+        tenant_id: UUID,
+        scheme: str,
+        identifier: str,
+        published_only: bool = False,
+        user_subject: str | None = None,
+        is_tenant_admin: bool = False,
+    ) -> DPP:
+        dpps, _ = await self.search_dpps(
+            tenant_id=tenant_id,
+            limit=1,
+            cursor=None,
+            identifier=identifier,
+            scheme=scheme,
+            status=DPPStatus.PUBLISHED.value if published_only else None,
+            published_only=published_only,
+            user_subject=user_subject,
+            is_tenant_admin=is_tenant_admin,
+        )
+        if not dpps:
+            raise CENAPINotFoundError("DPP not found for identifier")
+        return dpps[0]
+
+    async def update_dpp(
+        self,
+        *,
+        tenant_id: UUID,
+        dpp_id: UUID,
+        updated_by: str,
+        asset_ids_patch: dict[str, Any] | None,
+        visibility_scope: str | None,
+    ) -> DPP:
+        dpp = await self.get_dpp(tenant_id=tenant_id, dpp_id=dpp_id)
+
+        if asset_ids_patch is not None:
+            current_asset_ids = dict(dpp.asset_ids or {})
+            merged_asset_ids = {**current_asset_ids, **asset_ids_patch}
+
+            if (
+                dpp.status == DPPStatus.PUBLISHED
+                and self._identifier_critical_fields_changed(
+                    before=current_asset_ids,
+                    after=merged_asset_ids,
+                )
+            ):
+                raise CENAPIConflictError(
+                    "Published DPP identifier fields are immutable; supersede identifiers instead."
+                )
+
+            dpp.asset_ids = merged_asset_ids
+            if self._settings.cen_dpp_enabled:
+                try:
+                    await self._identifier_service.ensure_dpp_product_identifier_from_asset_ids(
+                        dpp=dpp,
+                        created_by=updated_by,
+                    )
+                except IdentifierGovernanceError as exc:
+                    raise CENAPIError(str(exc)) from exc
+
+        if visibility_scope is not None:
+            try:
+                dpp.visibility_scope = VisibilityScope(visibility_scope)
+            except ValueError as exc:
+                raise CENAPIError("visibility_scope must be owner_team or tenant") from exc
+
+        await self._session.flush()
+        return dpp
+
+    async def archive_dpp(self, *, tenant_id: UUID, dpp_id: UUID) -> DPP:
+        try:
+            return await self._dpp_service.archive_dpp(dpp_id=dpp_id, tenant_id=tenant_id)
+        except ValueError as exc:
+            message = str(exc)
+            if "not found" in message.lower():
+                raise CENAPINotFoundError(message) from exc
+            raise CENAPIConflictError(message) from exc
+
+    async def publish_dpp(self, *, tenant_id: UUID, dpp_id: UUID, published_by: str) -> DPP:
+        try:
+            return await self._dpp_service.publish_dpp(
+                dpp_id=dpp_id,
+                tenant_id=tenant_id,
+                published_by_subject=published_by,
+            )
+        except ValueError as exc:
+            message = str(exc)
+            if "not found" in message.lower():
+                raise CENAPINotFoundError(message) from exc
+            raise CENAPIConflictError(message) from exc
+
+    async def validate_identifier(
+        self,
+        *,
+        entity_type: IdentifierEntityType,
+        scheme_code: str,
+        value_raw: str,
+        granularity: IdentifierGranularity | None,
+    ) -> str:
+        try:
+            canonical = self._identifier_service.canonicalize(
+                scheme_code=scheme_code,
+                value_raw=value_raw,
+            )
+            self._identifier_service.validate(
+                scheme_code=scheme_code,
+                value_canonical=canonical,
+                entity_type=entity_type,
+                granularity=_to_db_granularity(granularity),
+            )
+        except IdentifierGovernanceError as exc:
+            raise CENAPIError(str(exc)) from exc
+        return canonical
+
+    async def register_identifier(
+        self,
+        *,
+        tenant_id: UUID,
+        created_by: str,
+        entity_type: IdentifierEntityType,
+        scheme_code: str,
+        value_raw: str,
+        granularity: IdentifierGranularity | None,
+        dpp_id: UUID | None,
+        operator_id: UUID | None,
+        facility_id: UUID | None,
+    ) -> ExternalIdentifier:
+        try:
+            return await self._identifier_module.register_identifier(
+                tenant_id=tenant_id,
+                created_by=created_by,
+                entity_type=entity_type,
+                scheme_code=scheme_code,
+                value_raw=value_raw,
+                granularity=_to_db_granularity(granularity),
+                dpp_id=dpp_id,
+                operator_id=operator_id,
+                facility_id=facility_id,
+            )
+        except IdentifierGovernanceError as exc:
+            raise CENAPIError(str(exc)) from exc
+
+    async def supersede_identifier(
+        self,
+        *,
+        tenant_id: UUID,
+        identifier_id: UUID,
+        replacement_identifier_id: UUID,
+    ) -> ExternalIdentifier:
+        try:
+            return await self._identifier_module.supersede_identifier(
+                tenant_id=tenant_id,
+                identifier_id=identifier_id,
+                replacement_identifier_id=replacement_identifier_id,
+            )
+        except IdentifierGovernanceError as exc:
+            raise CENAPIError(str(exc)) from exc
+
+    async def sync_registry_for_dpp(
+        self,
+        *,
+        tenant_id: UUID,
+        dpp_id: UUID,
+        created_by: str,
+    ) -> None:
+        if not self._settings.registry_enabled:
+            raise CENFeatureDisabledError("Registry integration is disabled")
+        dpp = await self.get_published_dpp(tenant_id=tenant_id, dpp_id=dpp_id)
+        revision = await self._dpp_service.get_published_revision(dpp_id=dpp.id, tenant_id=tenant_id)
+        if revision is None:
+            raise CENAPIConflictError("Published revision not found")
+
+        service = BuiltInRegistryService(self._session)
+        submodel_base_url = (
+            self._settings.cors_origins[0] if self._settings.cors_origins else "http://localhost:8000"
+        )
+        await service.auto_register_from_dpp(
+            dpp=dpp,
+            revision=revision,
+            tenant_id=tenant_id,
+            created_by=created_by,
+            submodel_base_url=submodel_base_url,
+        )
+
+    async def sync_resolver_for_dpp(
+        self,
+        *,
+        tenant_id: UUID,
+        dpp_id: UUID,
+        created_by: str,
+    ) -> None:
+        if not self._settings.resolver_enabled:
+            raise CENFeatureDisabledError("Resolver integration is disabled")
+        dpp = await self.get_published_dpp(tenant_id=tenant_id, dpp_id=dpp_id)
+        service = ResolverService(self._session)
+        base_url = self._settings.resolver_base_url
+        if not base_url:
+            base_url = self._settings.cors_origins[0] if self._settings.cors_origins else "http://localhost:8000"
+        await service.auto_register_for_dpp(
+            dpp=dpp,
+            tenant_id=tenant_id,
+            created_by=created_by,
+            base_url=base_url,
+        )
+
+    async def to_cen_dpp_response(self, dpp: DPP) -> CENDPPResponse:
+        primary_identifier = await self._get_primary_product_identifier(
+            tenant_id=dpp.tenant_id,
+            dpp_id=dpp.id,
+        )
+        return CENDPPResponse(
+            id=dpp.id,
+            platform_id=dpp.id,
+            status=dpp.status.value,
+            asset_ids=dpp.asset_ids or {},
+            product_identifier=(
+                primary_identifier.value_canonical if primary_identifier else None
+            ),
+            identifier_scheme=(primary_identifier.scheme_code if primary_identifier else None),
+            granularity=_to_schema_granularity(
+                primary_identifier.granularity if primary_identifier else None
+            ),
+            created_at=dpp.created_at,
+            updated_at=dpp.updated_at,
+        )
+
+    async def _get_primary_product_identifier(
+        self,
+        *,
+        tenant_id: UUID,
+        dpp_id: UUID,
+    ) -> ExternalIdentifier | None:
+        stmt = (
+            select(ExternalIdentifier)
+            .join(DPPIdentifier, DPPIdentifier.external_identifier_id == ExternalIdentifier.id)
+            .where(
+                DPPIdentifier.tenant_id == tenant_id,
+                DPPIdentifier.dpp_id == dpp_id,
+                ExternalIdentifier.entity_type == IdentifierEntityType.PRODUCT,
+                ExternalIdentifier.status == ExternalIdentifierStatus.ACTIVE,
+            )
+            .order_by(ExternalIdentifier.issued_at.desc(), ExternalIdentifier.created_at.desc())
+            .limit(1)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    def _identifier_critical_fields_changed(
+        *,
+        before: dict[str, Any],
+        after: dict[str, Any],
+    ) -> bool:
+        for key in _IDENTIFIER_CRITICAL_KEYS:
+            if str(before.get(key, "")).strip() != str(after.get(key, "")).strip():
+                return True
+        return False
+
+    @staticmethod
+    def identifiers_to_response(identifier: ExternalIdentifier) -> dict[str, Any]:
+        return {
+            "id": identifier.id,
+            "tenant_id": identifier.tenant_id,
+            "entity_type": _to_schema_entity_type(identifier.entity_type),
+            "scheme_code": identifier.scheme_code,
+            "value_raw": identifier.value_raw,
+            "value_canonical": identifier.value_canonical,
+            "granularity": _to_schema_granularity(identifier.granularity),
+            "status": identifier.status.value,
+            "replaced_by_identifier_id": identifier.replaced_by_identifier_id,
+            "issued_at": identifier.issued_at,
+            "deprecates_at": identifier.deprecates_at,
+            "created_by_subject": identifier.created_by_subject,
+            "created_at": identifier.created_at,
+            "updated_at": identifier.updated_at,
+        }
+
+    async def get_public_dpp_responses(
+        self,
+        *,
+        dpps: Sequence[DPP],
+    ) -> list[CENDPPResponse]:
+        return [await self.to_cen_dpp_response(dpp) for dpp in dpps]

--- a/backend/app/modules/data_carriers/service.py
+++ b/backend/app/modules/data_carriers/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import csv
 import hashlib
 import io
@@ -429,7 +430,8 @@ class DataCarrierService:
         }
 
         if carrier.carrier_type == DataCarrierTypeDB.QR:
-            payload = self._qr_renderer.render(
+            payload = await asyncio.to_thread(
+                self._qr_renderer.render,
                 payload=carrier.encoded_uri,
                 output_type=output,
                 profile=profile,
@@ -442,7 +444,8 @@ class DataCarrierService:
             extension = output
         elif carrier.carrier_type == DataCarrierTypeDB.DATAMATRIX:
             try:
-                payload = self._datamatrix_renderer.render(
+                payload = await asyncio.to_thread(
+                    self._datamatrix_renderer.render,
                     payload=carrier.encoded_uri,
                     output_type=output,
                     profile=profile,
@@ -452,7 +455,8 @@ class DataCarrierService:
             media_type = "image/png"
             extension = "png"
         elif carrier.carrier_type == DataCarrierTypeDB.NFC:
-            payload = self._nfc_renderer.render(
+            payload = await asyncio.to_thread(
+                self._nfc_renderer.render,
                 payload=carrier.encoded_uri,
                 output_type=output,
                 profile=profile,

--- a/backend/app/modules/dpps/service.py
+++ b/backend/app/modules/dpps/service.py
@@ -119,11 +119,19 @@ class DPPService:
             )
             self._field_encryptor = DPPFieldEncryptor(key_encryptor)
 
+    def _is_cen_dpp_enabled(self) -> bool:
+        value = getattr(self._settings, "cen_dpp_enabled", False)
+        return value is True
+
+    def _is_cen_http_identifier_allowed(self) -> bool:
+        value = getattr(self._settings, "cen_allow_http_identifiers", False)
+        return value is True
+
     def _allowed_global_asset_uri_schemes(self) -> set[str]:
-        if not self._settings.cen_dpp_enabled:
+        if not self._is_cen_dpp_enabled():
             return {"http"}
         schemes = {"https"}
-        if self._settings.cen_allow_http_identifiers:
+        if self._is_cen_http_identifier_allowed():
             schemes.add("http")
         return schemes
 
@@ -2174,7 +2182,7 @@ class DPPService:
         if dpp.status == DPPStatus.ARCHIVED:
             raise ValueError("Cannot publish an archived DPP")
 
-        if self._settings.cen_dpp_enabled:
+        if self._is_cen_dpp_enabled():
             identifier_service = IdentifierService(self._session)
             try:
                 await identifier_service.ensure_dpp_product_identifier_from_asset_ids(

--- a/backend/app/modules/identifiers/__init__.py
+++ b/backend/app/modules/identifiers/__init__.py
@@ -1,0 +1,1 @@
+"""Identifier governance module."""

--- a/backend/app/modules/identifiers/router.py
+++ b/backend/app/modules/identifiers/router.py
@@ -153,7 +153,9 @@ async def register_identifier(
             facility_id=body.facility_id,
         )
     except IdentifierGovernanceError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
     await db.commit()
     await db.refresh(identifier)
     return _to_identifier_response(identifier)
@@ -200,7 +202,9 @@ async def get_identifier(
         tenant=tenant,
     )
     service = IdentifierModuleService(db)
-    identifier = await service.get_identifier(tenant_id=tenant.tenant_id, identifier_id=identifier_id)
+    identifier = await service.get_identifier(
+        tenant_id=tenant.tenant_id, identifier_id=identifier_id
+    )
     if identifier is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Identifier not found")
     return _to_identifier_response(identifier)
@@ -227,13 +231,17 @@ async def supersede_identifier(
             replacement_identifier_id=body.replacement_identifier_id,
         )
     except IdentifierGovernanceError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
     await db.commit()
     await db.refresh(identifier)
     return _to_identifier_response(identifier)
 
 
-@router.post("/operators", response_model=EconomicOperatorResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/operators", response_model=EconomicOperatorResponse, status_code=status.HTTP_201_CREATED
+)
 async def create_operator(
     body: EconomicOperatorCreateRequest,
     db: DbSession,
@@ -325,7 +333,9 @@ async def create_facility(
                 facility_id=facility.id,
             )
     except IdentifierGovernanceError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
     await db.commit()
     await db.refresh(facility)
     return _to_facility_response(facility)

--- a/backend/app/modules/identifiers/router.py
+++ b/backend/app/modules/identifiers/router.py
@@ -1,0 +1,355 @@
+"""Tenant-scoped identifier governance routes."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from app.core.security import require_access
+from app.core.tenancy import TenantPublisher
+from app.db.models import DataCarrierIdentityLevel as DBGranularity
+from app.db.models import EconomicOperator, ExternalIdentifier, Facility, IdentifierEntityType
+from app.db.session import DbSession
+from app.modules.identifiers.schemas import (
+    EconomicOperatorCreateRequest,
+    EconomicOperatorResponse,
+    ExternalIdentifierResponse,
+    FacilityCreateRequest,
+    FacilityResponse,
+    IdentifierGranularity,
+    IdentifierRegisterRequest,
+    IdentifierSupersedeRequest,
+    IdentifierValidateRequest,
+    IdentifierValidateResponse,
+)
+from app.modules.identifiers.schemas import (
+    IdentifierEntityType as SchemaEntityType,
+)
+from app.modules.identifiers.service import IdentifierModuleService
+from app.standards.cen_pren.identifiers_18219 import IdentifierGovernanceError
+
+router = APIRouter()
+
+
+def _to_db_entity_type(entity_type: SchemaEntityType) -> IdentifierEntityType:
+    return IdentifierEntityType(entity_type.value)
+
+
+def _to_db_granularity(granularity: IdentifierGranularity | None) -> DBGranularity | None:
+    if granularity is None:
+        return None
+    return DBGranularity(granularity.value)
+
+
+def _to_identifier_response(identifier: ExternalIdentifier) -> ExternalIdentifierResponse:
+    return ExternalIdentifierResponse(
+        id=identifier.id,
+        tenant_id=identifier.tenant_id,
+        entity_type=identifier.entity_type.value,
+        scheme_code=identifier.scheme_code,
+        value_raw=identifier.value_raw,
+        value_canonical=identifier.value_canonical,
+        granularity=identifier.granularity.value if identifier.granularity else None,
+        status=identifier.status.value,
+        replaced_by_identifier_id=identifier.replaced_by_identifier_id,
+        issued_at=identifier.issued_at,
+        deprecates_at=identifier.deprecates_at,
+        created_by_subject=identifier.created_by_subject,
+        created_at=identifier.created_at,
+        updated_at=identifier.updated_at,
+    )
+
+
+def _to_operator_response(operator: EconomicOperator) -> EconomicOperatorResponse:
+    return EconomicOperatorResponse(
+        id=operator.id,
+        tenant_id=operator.tenant_id,
+        legal_name=operator.legal_name,
+        country=operator.country,
+        metadata_json=operator.metadata_json,
+        created_by_subject=operator.created_by_subject,
+        created_at=operator.created_at,
+        updated_at=operator.updated_at,
+    )
+
+
+def _to_facility_response(facility: Facility) -> FacilityResponse:
+    return FacilityResponse(
+        id=facility.id,
+        tenant_id=facility.tenant_id,
+        operator_id=facility.operator_id,
+        facility_name=facility.facility_name,
+        address=facility.address,
+        metadata_json=facility.metadata_json,
+        created_by_subject=facility.created_by_subject,
+        created_at=facility.created_at,
+        updated_at=facility.updated_at,
+    )
+
+
+@router.post("/validate", response_model=IdentifierValidateResponse)
+async def validate_identifier(
+    body: IdentifierValidateRequest,
+    db: DbSession,
+    tenant: TenantPublisher,
+) -> IdentifierValidateResponse:
+    await require_access(
+        tenant.user,
+        "create",
+        {"type": "identifier", "owner_subject": tenant.user.sub},
+        tenant=tenant,
+    )
+    service = IdentifierModuleService(db)
+    try:
+        canonical = await service.validate_identifier(
+            scheme_code=body.scheme_code,
+            value_raw=body.value_raw,
+            entity_type=_to_db_entity_type(body.entity_type),
+            granularity=_to_db_granularity(body.granularity),
+        )
+    except IdentifierGovernanceError as exc:
+        return IdentifierValidateResponse(
+            valid=False,
+            entity_type=body.entity_type,
+            scheme_code=body.scheme_code,
+            value_raw=body.value_raw,
+            granularity=body.granularity,
+            errors=[str(exc)],
+        )
+    return IdentifierValidateResponse(
+        valid=True,
+        entity_type=body.entity_type,
+        scheme_code=body.scheme_code,
+        value_raw=body.value_raw,
+        value_canonical=canonical,
+        granularity=body.granularity,
+    )
+
+
+@router.post("", response_model=ExternalIdentifierResponse, status_code=status.HTTP_201_CREATED)
+async def register_identifier(
+    body: IdentifierRegisterRequest,
+    db: DbSession,
+    tenant: TenantPublisher,
+) -> ExternalIdentifierResponse:
+    await require_access(
+        tenant.user,
+        "create",
+        {"type": "identifier", "owner_subject": tenant.user.sub},
+        tenant=tenant,
+    )
+    service = IdentifierModuleService(db)
+    try:
+        identifier = await service.register_identifier(
+            tenant_id=tenant.tenant_id,
+            created_by=tenant.user.sub,
+            entity_type=_to_db_entity_type(body.entity_type),
+            scheme_code=body.scheme_code,
+            value_raw=body.value_raw,
+            granularity=_to_db_granularity(body.granularity),
+            dpp_id=body.dpp_id,
+            operator_id=body.operator_id,
+            facility_id=body.facility_id,
+        )
+    except IdentifierGovernanceError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    await db.commit()
+    await db.refresh(identifier)
+    return _to_identifier_response(identifier)
+
+
+@router.get("", response_model=list[ExternalIdentifierResponse])
+async def list_identifiers(
+    db: DbSession,
+    tenant: TenantPublisher,
+    entity_type: SchemaEntityType | None = Query(default=None),
+    scheme_code: str | None = Query(default=None),
+    status_filter: str | None = Query(default=None, alias="status"),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> list[ExternalIdentifierResponse]:
+    await require_access(
+        tenant.user,
+        "read",
+        {"type": "identifier", "owner_subject": tenant.user.sub},
+        tenant=tenant,
+    )
+    service = IdentifierModuleService(db)
+    identifiers = await service.list_identifiers(
+        tenant_id=tenant.tenant_id,
+        entity_type=_to_db_entity_type(entity_type) if entity_type else None,
+        scheme_code=scheme_code,
+        status=status_filter,
+        limit=limit,
+        offset=offset,
+    )
+    return [_to_identifier_response(item) for item in identifiers]
+
+
+@router.get("/{identifier_id:uuid}", response_model=ExternalIdentifierResponse)
+async def get_identifier(
+    identifier_id: UUID,
+    db: DbSession,
+    tenant: TenantPublisher,
+) -> ExternalIdentifierResponse:
+    await require_access(
+        tenant.user,
+        "read",
+        {"type": "identifier", "owner_subject": tenant.user.sub},
+        tenant=tenant,
+    )
+    service = IdentifierModuleService(db)
+    identifier = await service.get_identifier(tenant_id=tenant.tenant_id, identifier_id=identifier_id)
+    if identifier is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Identifier not found")
+    return _to_identifier_response(identifier)
+
+
+@router.post("/{identifier_id:uuid}/supersede", response_model=ExternalIdentifierResponse)
+async def supersede_identifier(
+    identifier_id: UUID,
+    body: IdentifierSupersedeRequest,
+    db: DbSession,
+    tenant: TenantPublisher,
+) -> ExternalIdentifierResponse:
+    await require_access(
+        tenant.user,
+        "update",
+        {"type": "identifier", "owner_subject": tenant.user.sub},
+        tenant=tenant,
+    )
+    service = IdentifierModuleService(db)
+    try:
+        identifier = await service.supersede_identifier(
+            tenant_id=tenant.tenant_id,
+            identifier_id=identifier_id,
+            replacement_identifier_id=body.replacement_identifier_id,
+        )
+    except IdentifierGovernanceError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    await db.commit()
+    await db.refresh(identifier)
+    return _to_identifier_response(identifier)
+
+
+@router.post("/operators", response_model=EconomicOperatorResponse, status_code=status.HTTP_201_CREATED)
+async def create_operator(
+    body: EconomicOperatorCreateRequest,
+    db: DbSession,
+    tenant: TenantPublisher,
+) -> EconomicOperatorResponse:
+    await require_access(
+        tenant.user,
+        "create",
+        {"type": "economic_operator", "owner_subject": tenant.user.sub},
+        tenant=tenant,
+    )
+    service = IdentifierModuleService(db)
+    operator = await service.create_operator(
+        tenant_id=tenant.tenant_id,
+        created_by=tenant.user.sub,
+        legal_name=body.legal_name,
+        country=body.country,
+        metadata_json=body.metadata_json,
+    )
+    if body.identifier is not None:
+        try:
+            await service.register_identifier(
+                tenant_id=tenant.tenant_id,
+                created_by=tenant.user.sub,
+                entity_type=IdentifierEntityType.OPERATOR,
+                scheme_code=body.identifier.scheme_code,
+                value_raw=body.identifier.value_raw,
+                granularity=_to_db_granularity(body.identifier.granularity),
+                operator_id=operator.id,
+            )
+        except IdentifierGovernanceError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(exc),
+            ) from exc
+    await db.commit()
+    await db.refresh(operator)
+    return _to_operator_response(operator)
+
+
+@router.get("/operators", response_model=list[EconomicOperatorResponse])
+async def list_operators(
+    db: DbSession,
+    tenant: TenantPublisher,
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> list[EconomicOperatorResponse]:
+    await require_access(
+        tenant.user,
+        "read",
+        {"type": "economic_operator", "owner_subject": tenant.user.sub},
+        tenant=tenant,
+    )
+    service = IdentifierModuleService(db)
+    operators = await service.list_operators(tenant_id=tenant.tenant_id, limit=limit, offset=offset)
+    return [_to_operator_response(item) for item in operators]
+
+
+@router.post("/facilities", response_model=FacilityResponse, status_code=status.HTTP_201_CREATED)
+async def create_facility(
+    body: FacilityCreateRequest,
+    db: DbSession,
+    tenant: TenantPublisher,
+) -> FacilityResponse:
+    await require_access(
+        tenant.user,
+        "create",
+        {"type": "facility", "owner_subject": tenant.user.sub},
+        tenant=tenant,
+    )
+    service = IdentifierModuleService(db)
+    try:
+        facility = await service.create_facility(
+            tenant_id=tenant.tenant_id,
+            created_by=tenant.user.sub,
+            operator_id=body.operator_id,
+            facility_name=body.facility_name,
+            address=body.address,
+            metadata_json=body.metadata_json,
+        )
+        if body.identifier is not None:
+            await service.register_identifier(
+                tenant_id=tenant.tenant_id,
+                created_by=tenant.user.sub,
+                entity_type=IdentifierEntityType.FACILITY,
+                scheme_code=body.identifier.scheme_code,
+                value_raw=body.identifier.value_raw,
+                granularity=_to_db_granularity(body.identifier.granularity),
+                facility_id=facility.id,
+            )
+    except IdentifierGovernanceError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    await db.commit()
+    await db.refresh(facility)
+    return _to_facility_response(facility)
+
+
+@router.get("/facilities", response_model=list[FacilityResponse])
+async def list_facilities(
+    db: DbSession,
+    tenant: TenantPublisher,
+    operator_id: UUID | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> list[FacilityResponse]:
+    await require_access(
+        tenant.user,
+        "read",
+        {"type": "facility", "owner_subject": tenant.user.sub},
+        tenant=tenant,
+    )
+    service = IdentifierModuleService(db)
+    facilities = await service.list_facilities(
+        tenant_id=tenant.tenant_id,
+        operator_id=operator_id,
+        limit=limit,
+        offset=offset,
+    )
+    return [_to_facility_response(item) for item in facilities]

--- a/backend/app/modules/identifiers/schemas.py
+++ b/backend/app/modules/identifiers/schemas.py
@@ -1,0 +1,108 @@
+"""Schemas for CEN identifier governance APIs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class IdentifierEntityType(str, Enum):
+    PRODUCT = "product"
+    OPERATOR = "operator"
+    FACILITY = "facility"
+
+
+class IdentifierGranularity(str, Enum):
+    MODEL = "model"
+    BATCH = "batch"
+    ITEM = "item"
+
+
+class IdentifierValidateRequest(BaseModel):
+    entity_type: IdentifierEntityType
+    scheme_code: str = Field(min_length=1, max_length=64)
+    value_raw: str = Field(min_length=1)
+    granularity: IdentifierGranularity | None = None
+
+
+class IdentifierValidateResponse(BaseModel):
+    valid: bool
+    entity_type: IdentifierEntityType
+    scheme_code: str
+    value_raw: str
+    value_canonical: str | None = None
+    granularity: IdentifierGranularity | None = None
+    errors: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class IdentifierRegisterRequest(BaseModel):
+    entity_type: IdentifierEntityType
+    scheme_code: str = Field(min_length=1, max_length=64)
+    value_raw: str = Field(min_length=1)
+    granularity: IdentifierGranularity | None = None
+    dpp_id: UUID | None = None
+    operator_id: UUID | None = None
+    facility_id: UUID | None = None
+
+
+class IdentifierSupersedeRequest(BaseModel):
+    replacement_identifier_id: UUID
+
+
+class ExternalIdentifierResponse(BaseModel):
+    id: UUID
+    tenant_id: UUID
+    entity_type: IdentifierEntityType
+    scheme_code: str
+    value_raw: str
+    value_canonical: str
+    granularity: IdentifierGranularity | None = None
+    status: str
+    replaced_by_identifier_id: UUID | None = None
+    issued_at: datetime | None = None
+    deprecates_at: datetime | None = None
+    created_by_subject: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class EconomicOperatorCreateRequest(BaseModel):
+    legal_name: str = Field(min_length=1, max_length=255)
+    country: str | None = Field(default=None, max_length=8)
+    metadata_json: dict[str, object] = Field(default_factory=dict)
+    identifier: IdentifierRegisterRequest | None = None
+
+
+class EconomicOperatorResponse(BaseModel):
+    id: UUID
+    tenant_id: UUID
+    legal_name: str
+    country: str | None = None
+    metadata_json: dict[str, object]
+    created_by_subject: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class FacilityCreateRequest(BaseModel):
+    operator_id: UUID
+    facility_name: str = Field(min_length=1, max_length=255)
+    address: dict[str, object] = Field(default_factory=dict)
+    metadata_json: dict[str, object] = Field(default_factory=dict)
+    identifier: IdentifierRegisterRequest | None = None
+
+
+class FacilityResponse(BaseModel):
+    id: UUID
+    tenant_id: UUID
+    operator_id: UUID
+    facility_name: str
+    address: dict[str, object]
+    metadata_json: dict[str, object]
+    created_by_subject: str
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/modules/identifiers/service.py
+++ b/backend/app/modules/identifiers/service.py
@@ -53,7 +53,9 @@ class IdentifierModuleService:
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
 
-    async def get_identifier(self, *, tenant_id: UUID, identifier_id: UUID) -> ExternalIdentifier | None:
+    async def get_identifier(
+        self, *, tenant_id: UUID, identifier_id: UUID
+    ) -> ExternalIdentifier | None:
         result = await self._session.execute(
             select(ExternalIdentifier).where(
                 ExternalIdentifier.id == identifier_id,
@@ -158,7 +160,9 @@ class IdentifierModuleService:
         await self._session.flush()
         return operator
 
-    async def list_operators(self, *, tenant_id: UUID, limit: int = 100, offset: int = 0) -> list[EconomicOperator]:
+    async def list_operators(
+        self, *, tenant_id: UUID, limit: int = 100, offset: int = 0
+    ) -> list[EconomicOperator]:
         result = await self._session.execute(
             select(EconomicOperator)
             .where(EconomicOperator.tenant_id == tenant_id)
@@ -191,7 +195,9 @@ class IdentifierModuleService:
         await self._session.flush()
         return facility
 
-    async def list_facilities(self, *, tenant_id: UUID, operator_id: UUID | None = None, limit: int = 100, offset: int = 0) -> list[Facility]:
+    async def list_facilities(
+        self, *, tenant_id: UUID, operator_id: UUID | None = None, limit: int = 100, offset: int = 0
+    ) -> list[Facility]:
         stmt = select(Facility).where(Facility.tenant_id == tenant_id)
         if operator_id is not None:
             stmt = stmt.where(Facility.operator_id == operator_id)
@@ -208,7 +214,9 @@ class IdentifierModuleService:
             raise IdentifierGovernanceError("DPP not found")
         return dpp
 
-    async def _assert_operator_exists(self, *, tenant_id: UUID, operator_id: UUID) -> EconomicOperator:
+    async def _assert_operator_exists(
+        self, *, tenant_id: UUID, operator_id: UUID
+    ) -> EconomicOperator:
         result = await self._session.execute(
             select(EconomicOperator).where(
                 EconomicOperator.id == operator_id,

--- a/backend/app/modules/identifiers/service.py
+++ b/backend/app/modules/identifiers/service.py
@@ -1,0 +1,285 @@
+"""Service layer for identifier governance entities and links."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import (
+    DPP,
+    EconomicOperator,
+    ExternalIdentifier,
+    ExternalIdentifierStatus,
+    Facility,
+    FacilityIdentifier,
+    IdentifierEntityType,
+    OperatorIdentifier,
+)
+from app.db.models import DataCarrierIdentityLevel as DBGranularity
+from app.standards.cen_pren.identifiers_18219 import IdentifierGovernanceError, IdentifierService
+
+
+class IdentifierModuleService:
+    """High-level operations for identifier and entity endpoints."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+        self._service = IdentifierService(session)
+
+    async def list_identifiers(
+        self,
+        *,
+        tenant_id: UUID,
+        entity_type: IdentifierEntityType | None = None,
+        scheme_code: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[ExternalIdentifier]:
+        stmt = select(ExternalIdentifier).where(ExternalIdentifier.tenant_id == tenant_id)
+        if entity_type is not None:
+            stmt = stmt.where(ExternalIdentifier.entity_type == entity_type)
+        if scheme_code is not None:
+            stmt = stmt.where(ExternalIdentifier.scheme_code == scheme_code.strip().lower())
+        if status is not None:
+            try:
+                status_value = ExternalIdentifierStatus(status.strip().lower())
+            except ValueError as exc:
+                raise IdentifierGovernanceError(f"Unsupported status filter '{status}'") from exc
+            stmt = stmt.where(ExternalIdentifier.status == status_value)
+        stmt = stmt.order_by(ExternalIdentifier.created_at.desc()).limit(limit).offset(offset)
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_identifier(self, *, tenant_id: UUID, identifier_id: UUID) -> ExternalIdentifier | None:
+        result = await self._session.execute(
+            select(ExternalIdentifier).where(
+                ExternalIdentifier.id == identifier_id,
+                ExternalIdentifier.tenant_id == tenant_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def validate_identifier(
+        self,
+        *,
+        scheme_code: str,
+        value_raw: str,
+        entity_type: IdentifierEntityType,
+        granularity: DBGranularity | None,
+    ) -> str:
+        canonical = self._service.canonicalize(scheme_code, value_raw)
+        self._service.validate(
+            scheme_code=scheme_code,
+            value_canonical=canonical,
+            entity_type=entity_type,
+            granularity=granularity,
+        )
+        return canonical
+
+    async def register_identifier(
+        self,
+        *,
+        tenant_id: UUID,
+        created_by: str,
+        entity_type: IdentifierEntityType,
+        scheme_code: str,
+        value_raw: str,
+        granularity: DBGranularity | None,
+        dpp_id: UUID | None = None,
+        operator_id: UUID | None = None,
+        facility_id: UUID | None = None,
+    ) -> ExternalIdentifier:
+        identifier = await self._service.reserve_or_register(
+            tenant_id=tenant_id,
+            created_by=created_by,
+            entity_type=entity_type,
+            scheme_code=scheme_code,
+            value_raw=value_raw,
+            granularity=granularity,
+        )
+
+        if dpp_id is not None:
+            await self._assert_dpp_exists(tenant_id=tenant_id, dpp_id=dpp_id)
+            await self._service.link_identifier_to_dpp(
+                tenant_id=tenant_id,
+                dpp_id=dpp_id,
+                external_identifier_id=identifier.id,
+            )
+        if operator_id is not None:
+            await self._assert_operator_exists(tenant_id=tenant_id, operator_id=operator_id)
+            await self._link_operator_identifier(
+                tenant_id=tenant_id,
+                operator_id=operator_id,
+                external_identifier_id=identifier.id,
+            )
+        if facility_id is not None:
+            await self._assert_facility_exists(tenant_id=tenant_id, facility_id=facility_id)
+            await self._link_facility_identifier(
+                tenant_id=tenant_id,
+                facility_id=facility_id,
+                external_identifier_id=identifier.id,
+            )
+
+        return identifier
+
+    async def supersede_identifier(
+        self,
+        *,
+        tenant_id: UUID,
+        identifier_id: UUID,
+        replacement_identifier_id: UUID,
+    ) -> ExternalIdentifier:
+        return await self._service.supersede(
+            tenant_id=tenant_id,
+            identifier_id=identifier_id,
+            replacement_identifier_id=replacement_identifier_id,
+        )
+
+    async def create_operator(
+        self,
+        *,
+        tenant_id: UUID,
+        created_by: str,
+        legal_name: str,
+        country: str | None,
+        metadata_json: dict[str, object],
+    ) -> EconomicOperator:
+        operator = EconomicOperator(
+            tenant_id=tenant_id,
+            legal_name=legal_name.strip(),
+            country=country.strip().upper() if country else None,
+            metadata_json=metadata_json,
+            created_by_subject=created_by,
+        )
+        self._session.add(operator)
+        await self._session.flush()
+        return operator
+
+    async def list_operators(self, *, tenant_id: UUID, limit: int = 100, offset: int = 0) -> list[EconomicOperator]:
+        result = await self._session.execute(
+            select(EconomicOperator)
+            .where(EconomicOperator.tenant_id == tenant_id)
+            .order_by(EconomicOperator.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        return list(result.scalars().all())
+
+    async def create_facility(
+        self,
+        *,
+        tenant_id: UUID,
+        created_by: str,
+        operator_id: UUID,
+        facility_name: str,
+        address: dict[str, object],
+        metadata_json: dict[str, object],
+    ) -> Facility:
+        await self._assert_operator_exists(tenant_id=tenant_id, operator_id=operator_id)
+        facility = Facility(
+            tenant_id=tenant_id,
+            operator_id=operator_id,
+            facility_name=facility_name.strip(),
+            address=address,
+            metadata_json=metadata_json,
+            created_by_subject=created_by,
+        )
+        self._session.add(facility)
+        await self._session.flush()
+        return facility
+
+    async def list_facilities(self, *, tenant_id: UUID, operator_id: UUID | None = None, limit: int = 100, offset: int = 0) -> list[Facility]:
+        stmt = select(Facility).where(Facility.tenant_id == tenant_id)
+        if operator_id is not None:
+            stmt = stmt.where(Facility.operator_id == operator_id)
+        stmt = stmt.order_by(Facility.created_at.desc()).limit(limit).offset(offset)
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def _assert_dpp_exists(self, *, tenant_id: UUID, dpp_id: UUID) -> DPP:
+        result = await self._session.execute(
+            select(DPP).where(DPP.id == dpp_id, DPP.tenant_id == tenant_id)
+        )
+        dpp = result.scalar_one_or_none()
+        if dpp is None:
+            raise IdentifierGovernanceError("DPP not found")
+        return dpp
+
+    async def _assert_operator_exists(self, *, tenant_id: UUID, operator_id: UUID) -> EconomicOperator:
+        result = await self._session.execute(
+            select(EconomicOperator).where(
+                EconomicOperator.id == operator_id,
+                EconomicOperator.tenant_id == tenant_id,
+            )
+        )
+        operator = result.scalar_one_or_none()
+        if operator is None:
+            raise IdentifierGovernanceError("Operator not found")
+        return operator
+
+    async def _assert_facility_exists(self, *, tenant_id: UUID, facility_id: UUID) -> Facility:
+        result = await self._session.execute(
+            select(Facility).where(
+                Facility.id == facility_id,
+                Facility.tenant_id == tenant_id,
+            )
+        )
+        facility = result.scalar_one_or_none()
+        if facility is None:
+            raise IdentifierGovernanceError("Facility not found")
+        return facility
+
+    async def _link_operator_identifier(
+        self,
+        *,
+        tenant_id: UUID,
+        operator_id: UUID,
+        external_identifier_id: UUID,
+    ) -> OperatorIdentifier:
+        existing = await self._session.execute(
+            select(OperatorIdentifier).where(
+                OperatorIdentifier.tenant_id == tenant_id,
+                OperatorIdentifier.operator_id == operator_id,
+                OperatorIdentifier.external_identifier_id == external_identifier_id,
+            )
+        )
+        found = existing.scalar_one_or_none()
+        if found is not None:
+            return found
+        link = OperatorIdentifier(
+            tenant_id=tenant_id,
+            operator_id=operator_id,
+            external_identifier_id=external_identifier_id,
+        )
+        self._session.add(link)
+        await self._session.flush()
+        return link
+
+    async def _link_facility_identifier(
+        self,
+        *,
+        tenant_id: UUID,
+        facility_id: UUID,
+        external_identifier_id: UUID,
+    ) -> FacilityIdentifier:
+        existing = await self._session.execute(
+            select(FacilityIdentifier).where(
+                FacilityIdentifier.tenant_id == tenant_id,
+                FacilityIdentifier.facility_id == facility_id,
+                FacilityIdentifier.external_identifier_id == external_identifier_id,
+            )
+        )
+        found = existing.scalar_one_or_none()
+        if found is not None:
+            return found
+        link = FacilityIdentifier(
+            tenant_id=tenant_id,
+            facility_id=facility_id,
+            external_identifier_id=external_identifier_id,
+        )
+        self._session.add(link)
+        await self._session.flush()
+        return link

--- a/backend/app/modules/qr/service.py
+++ b/backend/app/modules/qr/service.py
@@ -50,6 +50,8 @@ class QRCodeService:
         background_color: str = "#FFFFFF",
         include_text: bool = False,
         text_label: str | None = None,
+        error_correction: str = "H",
+        quiet_zone_modules: int = 4,
     ) -> bytes:
         """
         Generate a QR code for a DPP URL.
@@ -71,11 +73,18 @@ class QRCodeService:
         bg_color = self._hex_to_rgb(background_color)
 
         # Create QR code instance
+        correction_level = {
+            "L": qrcode.constants.ERROR_CORRECT_L,
+            "M": qrcode.constants.ERROR_CORRECT_M,
+            "Q": qrcode.constants.ERROR_CORRECT_Q,
+            "H": qrcode.constants.ERROR_CORRECT_H,
+        }.get(str(error_correction).upper(), qrcode.constants.ERROR_CORRECT_H)
+
         qr = qrcode.QRCode(
             version=None,  # Auto-determine version
-            error_correction=qrcode.constants.ERROR_CORRECT_H,  # High error correction for logo
+            error_correction=correction_level,
             box_size=10,
-            border=4,
+            border=max(1, int(quiet_zone_modules)),
         )
 
         qr.add_data(dpp_url)

--- a/backend/app/standards/__init__.py
+++ b/backend/app/standards/__init__.py
@@ -1,0 +1,1 @@
+"""Standards profiles and implementation helpers."""

--- a/backend/app/standards/cen_pren/__init__.py
+++ b/backend/app/standards/cen_pren/__init__.py
@@ -1,0 +1,9 @@
+"""CEN prEN standards integration helpers."""
+
+from app.standards.cen_pren.profiles import CENProfiles, get_cen_profiles, standards_profile_header
+
+__all__ = [
+    "CENProfiles",
+    "get_cen_profiles",
+    "standards_profile_header",
+]

--- a/backend/app/standards/cen_pren/data_carriers_18220/__init__.py
+++ b/backend/app/standards/cen_pren/data_carriers_18220/__init__.py
@@ -1,0 +1,1 @@
+"""Data carrier constraints and rendering primitives for CEN prEN 18220."""

--- a/backend/app/standards/cen_pren/data_carriers_18220/renderers/__init__.py
+++ b/backend/app/standards/cen_pren/data_carriers_18220/renderers/__init__.py
@@ -1,0 +1,11 @@
+"""Carrier renderer abstractions for CEN data-carrier handling."""
+
+from app.standards.cen_pren.data_carriers_18220.renderers.datamatrix import DataMatrixRenderer
+from app.standards.cen_pren.data_carriers_18220.renderers.nfc_ndef import NFCRenderer
+from app.standards.cen_pren.data_carriers_18220.renderers.qr import QRRenderer
+
+__all__ = [
+    "QRRenderer",
+    "DataMatrixRenderer",
+    "NFCRenderer",
+]

--- a/backend/app/standards/cen_pren/data_carriers_18220/renderers/datamatrix.py
+++ b/backend/app/standards/cen_pren/data_carriers_18220/renderers/datamatrix.py
@@ -1,0 +1,63 @@
+"""DataMatrix renderer with optional runtime dependency."""
+
+from __future__ import annotations
+
+import io
+
+from PIL import Image
+
+
+class DataMatrixRenderer:
+    """Render DataMatrix payloads when pylibdmtx/libdmtx is available."""
+
+    @staticmethod
+    def is_available() -> bool:
+        try:
+            from pylibdmtx.pylibdmtx import encode  # type: ignore[import-not-found]
+        except Exception:
+            return False
+        return encode is not None
+
+    def validate_payload(self, payload: str, _profile: dict[str, object]) -> None:
+        if not payload.strip():
+            raise ValueError("DataMatrix payload cannot be empty")
+        if len(payload.encode("utf-8")) > 2000:
+            raise ValueError("DataMatrix payload is too large for configured profile")
+
+    def render(
+        self,
+        *,
+        payload: str,
+        output_type: str,
+        profile: dict[str, object],
+    ) -> bytes:
+        self.validate_payload(payload, profile)
+
+        if output_type != "png":
+            raise ValueError("DataMatrix currently supports png output only")
+
+        try:
+            from pylibdmtx.pylibdmtx import encode
+        except Exception as exc:
+            raise NotImplementedError(
+                "DataMatrix rendering unavailable. Install pylibdmtx and libdmtx runtime dependencies."
+            ) from exc
+
+        encoded = encode(payload.encode("utf-8"))
+        image = Image.frombytes("RGB", (encoded.width, encoded.height), encoded.pixels)
+        target_size = self._profile_int(profile, "size", encoded.width)
+        if target_size > 0 and target_size != encoded.width:
+            image = image.resize((target_size, target_size))
+
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG", optimize=True)
+        buffer.seek(0)
+        return buffer.read()
+
+    @staticmethod
+    def _profile_int(profile: dict[str, object], key: str, default: int) -> int:
+        raw = profile.get(key, default)
+        try:
+            return int(str(raw))
+        except ValueError as exc:
+            raise ValueError(f"{key} must be an integer") from exc

--- a/backend/app/standards/cen_pren/data_carriers_18220/renderers/nfc_ndef.py
+++ b/backend/app/standards/cen_pren/data_carriers_18220/renderers/nfc_ndef.py
@@ -1,0 +1,46 @@
+"""NFC renderer producing NDEF URI records."""
+
+from __future__ import annotations
+
+
+class NFCRenderer:
+    """Generate an NFC Forum NDEF URI record payload."""
+
+    def validate_payload(self, payload: str, profile: dict[str, object]) -> None:
+        if not payload.strip():
+            raise ValueError("NFC payload cannot be empty")
+        memory_bytes = self._profile_int(profile, "nfc_memory_bytes", 512)
+        if memory_bytes < 16:
+            raise ValueError("nfc_memory_bytes must be at least 16")
+        estimated = len(payload.encode("utf-8")) + 5
+        if estimated > memory_bytes:
+            raise ValueError(
+                f"NFC payload exceeds configured memory ({estimated} bytes > {memory_bytes})"
+            )
+
+    def render(
+        self,
+        *,
+        payload: str,
+        output_type: str,
+        profile: dict[str, object],
+    ) -> bytes:
+        self.validate_payload(payload, profile)
+        if output_type != "ndef":
+            raise ValueError("NFC renderer requires output_type='ndef'")
+
+        uri_bytes = payload.encode("utf-8")
+        if len(uri_bytes) > 255:
+            raise ValueError("NFC URI payload too large for short NDEF record")
+
+        # NDEF short record, TNF=Well-known, type='U', no URI abbreviation prefix.
+        header = bytes([0xD1, 0x01, len(uri_bytes) + 1, 0x55, 0x00])
+        return header + uri_bytes
+
+    @staticmethod
+    def _profile_int(profile: dict[str, object], key: str, default: int) -> int:
+        raw = profile.get(key, default)
+        try:
+            return int(str(raw))
+        except ValueError as exc:
+            raise ValueError(f"{key} must be an integer") from exc

--- a/backend/app/standards/cen_pren/data_carriers_18220/renderers/qr.py
+++ b/backend/app/standards/cen_pren/data_carriers_18220/renderers/qr.py
@@ -37,9 +37,7 @@ class QRRenderer:
             background_color=str(profile.get("background_color", "#FFFFFF")),
             include_text=bool(profile.get("include_text", True)),
             text_label=(
-                str(profile["text_label"])
-                if profile.get("text_label") is not None
-                else None
+                str(profile["text_label"]) if profile.get("text_label") is not None else None
             ),
             error_correction=str(profile.get("error_correction", "H")).upper(),
             quiet_zone_modules=self._profile_int(profile, "quiet_zone_modules", 4),

--- a/backend/app/standards/cen_pren/data_carriers_18220/renderers/qr.py
+++ b/backend/app/standards/cen_pren/data_carriers_18220/renderers/qr.py
@@ -1,0 +1,54 @@
+"""QR renderer honoring profile-driven error correction and quiet zones."""
+
+from __future__ import annotations
+
+from app.modules.qr.service import QRCodeService
+
+
+class QRRenderer:
+    """Render QR payloads using configurable profile attributes."""
+
+    def __init__(self) -> None:
+        self._qr = QRCodeService()
+
+    def validate_payload(self, payload: str, profile: dict[str, object]) -> None:
+        if not payload.strip():
+            raise ValueError("QR payload cannot be empty")
+        error_correction = str(profile.get("error_correction", "H")).upper()
+        if error_correction not in {"L", "M", "Q", "H"}:
+            raise ValueError("error_correction must be one of L, M, Q, H")
+        quiet_zone_modules = self._profile_int(profile, "quiet_zone_modules", 4)
+        if quiet_zone_modules < 1 or quiet_zone_modules > 16:
+            raise ValueError("quiet_zone_modules must be between 1 and 16")
+
+    def render(
+        self,
+        *,
+        payload: str,
+        output_type: str,
+        profile: dict[str, object],
+    ) -> bytes:
+        self.validate_payload(payload, profile)
+        return self._qr.generate_qr_code(
+            dpp_url=payload,
+            format=output_type,  # type: ignore[arg-type]
+            size=self._profile_int(profile, "size", 400),
+            foreground_color=str(profile.get("foreground_color", "#000000")),
+            background_color=str(profile.get("background_color", "#FFFFFF")),
+            include_text=bool(profile.get("include_text", True)),
+            text_label=(
+                str(profile["text_label"])
+                if profile.get("text_label") is not None
+                else None
+            ),
+            error_correction=str(profile.get("error_correction", "H")).upper(),
+            quiet_zone_modules=self._profile_int(profile, "quiet_zone_modules", 4),
+        )
+
+    @staticmethod
+    def _profile_int(profile: dict[str, object], key: str, default: int) -> int:
+        raw = profile.get(key, default)
+        try:
+            return int(str(raw))
+        except ValueError as exc:
+            raise ValueError(f"{key} must be an integer") from exc

--- a/backend/app/standards/cen_pren/identifiers_18219/__init__.py
+++ b/backend/app/standards/cen_pren/identifiers_18219/__init__.py
@@ -1,0 +1,8 @@
+"""Identifier governance primitives for CEN prEN 18219."""
+
+from app.standards.cen_pren.identifiers_18219.service import (
+    IdentifierGovernanceError,
+    IdentifierService,
+)
+
+__all__ = ["IdentifierGovernanceError", "IdentifierService"]

--- a/backend/app/standards/cen_pren/identifiers_18219/service.py
+++ b/backend/app/standards/cen_pren/identifiers_18219/service.py
@@ -1,0 +1,271 @@
+"""CEN prEN 18219 identifier governance service."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from urllib.parse import urlparse, urlunparse
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import get_settings
+from app.db.models import (
+    DPP,
+    DataCarrierIdentityLevel,
+    DPPIdentifier,
+    ExternalIdentifier,
+    ExternalIdentifierStatus,
+    IdentifierEntityType,
+    IdentifierScheme,
+)
+
+
+class IdentifierGovernanceError(ValueError):
+    """Raised when identifier governance checks fail."""
+
+
+class IdentifierService:
+    """Canonicalization, validation, registration, and supersede logic."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+        self._settings = get_settings()
+
+    async def get_scheme(self, scheme_code: str) -> IdentifierScheme | None:
+        result = await self._session.execute(
+            select(IdentifierScheme).where(IdentifierScheme.code == scheme_code.strip().lower())
+        )
+        return result.scalar_one_or_none()
+
+    def canonicalize(self, scheme_code: str, value_raw: str) -> str:
+        scheme = scheme_code.strip().lower()
+        raw = value_raw.strip()
+        if not raw:
+            raise IdentifierGovernanceError("Identifier value cannot be empty")
+
+        if scheme in {"gs1_gtin", "gln"}:
+            return "".join(ch for ch in raw if ch.isdigit())
+        if scheme == "eori":
+            return raw.replace(" ", "").upper()
+        if scheme in {"iec61406", "direct_url", "uri"}:
+            parsed = urlparse(raw)
+            if not parsed.scheme or not parsed.netloc:
+                raise IdentifierGovernanceError("URI-based identifier must include scheme and host")
+            normalized_scheme = parsed.scheme.lower()
+            if normalized_scheme not in {"http", "https"}:
+                raise IdentifierGovernanceError("URI-based identifier must use http or https")
+            if normalized_scheme == "http" and not self._settings.cen_allow_http_identifiers:
+                raise IdentifierGovernanceError(
+                    "http identifiers are disabled by CEN profile policy"
+                )
+            normalized = parsed._replace(
+                scheme=normalized_scheme,
+                netloc=parsed.netloc.lower(),
+                fragment="",
+            )
+            return urlunparse(normalized)
+
+        return raw
+
+    def validate(
+        self,
+        *,
+        scheme_code: str,
+        value_canonical: str,
+        entity_type: IdentifierEntityType,
+        granularity: DataCarrierIdentityLevel | None = None,
+    ) -> None:
+        if not value_canonical:
+            raise IdentifierGovernanceError("Canonical identifier value cannot be empty")
+
+        scheme = scheme_code.strip().lower()
+        if scheme in {"gs1_gtin"} and len(value_canonical) not in {8, 12, 13, 14}:
+            raise IdentifierGovernanceError("GS1 GTIN must be 8, 12, 13, or 14 digits")
+        if scheme == "gln" and len(value_canonical) != 13:
+            raise IdentifierGovernanceError("GLN must be 13 digits")
+        if scheme == "eori" and len(value_canonical) < 8:
+            raise IdentifierGovernanceError("EORI must be at least 8 characters")
+
+        if entity_type == IdentifierEntityType.PRODUCT and granularity is None:
+            raise IdentifierGovernanceError("Product identifiers must include granularity")
+
+    async def reserve_or_register(
+        self,
+        *,
+        tenant_id: UUID,
+        created_by: str,
+        entity_type: IdentifierEntityType,
+        scheme_code: str,
+        value_raw: str,
+        granularity: DataCarrierIdentityLevel | None = None,
+        issued_at: datetime | None = None,
+    ) -> ExternalIdentifier:
+        scheme = await self.get_scheme(scheme_code)
+        if scheme is None:
+            raise IdentifierGovernanceError(f"Unsupported identifier scheme: {scheme_code}")
+
+        canonical = self.canonicalize(scheme.code, value_raw)
+        self.validate(
+            scheme_code=scheme.code,
+            value_canonical=canonical,
+            entity_type=entity_type,
+            granularity=granularity,
+        )
+
+        existing = await self._session.execute(
+            select(ExternalIdentifier).where(
+                ExternalIdentifier.scheme_code == scheme.code,
+                ExternalIdentifier.value_canonical == canonical,
+            )
+        )
+        found = existing.scalar_one_or_none()
+        if found is not None:
+            return found
+
+        identifier = ExternalIdentifier(
+            tenant_id=tenant_id,
+            entity_type=entity_type,
+            scheme_code=scheme.code,
+            value_raw=value_raw.strip(),
+            value_canonical=canonical,
+            granularity=granularity,
+            status=ExternalIdentifierStatus.ACTIVE,
+            issued_at=issued_at or datetime.now(UTC),
+            created_by_subject=created_by,
+        )
+        self._session.add(identifier)
+        try:
+            await self._session.flush()
+        except IntegrityError:
+            await self._session.rollback()
+            retry = await self._session.execute(
+                select(ExternalIdentifier).where(
+                    ExternalIdentifier.scheme_code == scheme.code,
+                    ExternalIdentifier.value_canonical == canonical,
+                )
+            )
+            resolved = retry.scalar_one_or_none()
+            if resolved is None:
+                raise
+            return resolved
+        return identifier
+
+    async def supersede(
+        self,
+        *,
+        tenant_id: UUID,
+        identifier_id: UUID,
+        replacement_identifier_id: UUID,
+    ) -> ExternalIdentifier:
+        result = await self._session.execute(
+            select(ExternalIdentifier).where(
+                ExternalIdentifier.id == identifier_id,
+                ExternalIdentifier.tenant_id == tenant_id,
+            )
+        )
+        current = result.scalar_one_or_none()
+        if current is None:
+            raise IdentifierGovernanceError("Identifier not found")
+
+        replacement_result = await self._session.execute(
+            select(ExternalIdentifier).where(
+                ExternalIdentifier.id == replacement_identifier_id,
+                ExternalIdentifier.tenant_id == tenant_id,
+            )
+        )
+        replacement = replacement_result.scalar_one_or_none()
+        if replacement is None:
+            raise IdentifierGovernanceError("Replacement identifier not found")
+
+        current.status = ExternalIdentifierStatus.DEPRECATED
+        current.replaced_by_identifier_id = replacement.id
+        current.deprecates_at = datetime.now(UTC)
+        await self._session.flush()
+        return current
+
+    async def link_identifier_to_dpp(
+        self,
+        *,
+        tenant_id: UUID,
+        dpp_id: UUID,
+        external_identifier_id: UUID,
+    ) -> DPPIdentifier:
+        existing = await self._session.execute(
+            select(DPPIdentifier).where(
+                DPPIdentifier.tenant_id == tenant_id,
+                DPPIdentifier.dpp_id == dpp_id,
+                DPPIdentifier.external_identifier_id == external_identifier_id,
+            )
+        )
+        found = existing.scalar_one_or_none()
+        if found is not None:
+            return found
+        link = DPPIdentifier(
+            tenant_id=tenant_id,
+            dpp_id=dpp_id,
+            external_identifier_id=external_identifier_id,
+        )
+        self._session.add(link)
+        await self._session.flush()
+        return link
+
+    async def has_active_product_identifier(self, *, tenant_id: UUID, dpp_id: UUID) -> bool:
+        result = await self._session.execute(
+            select(DPPIdentifier)
+            .join(
+                ExternalIdentifier,
+                DPPIdentifier.external_identifier_id == ExternalIdentifier.id,
+            )
+            .where(
+                DPPIdentifier.tenant_id == tenant_id,
+                DPPIdentifier.dpp_id == dpp_id,
+                ExternalIdentifier.entity_type == IdentifierEntityType.PRODUCT,
+                ExternalIdentifier.status == ExternalIdentifierStatus.ACTIVE,
+            )
+            .limit(1)
+        )
+        return result.scalar_one_or_none() is not None
+
+    async def ensure_dpp_product_identifier_from_asset_ids(
+        self,
+        *,
+        dpp: DPP,
+        created_by: str,
+    ) -> ExternalIdentifier | None:
+        asset_ids = dpp.asset_ids or {}
+        gtin = str(asset_ids.get("gtin", "")).strip()
+        if gtin:
+            identifier = await self.reserve_or_register(
+                tenant_id=dpp.tenant_id,
+                created_by=created_by,
+                entity_type=IdentifierEntityType.PRODUCT,
+                scheme_code="gs1_gtin",
+                value_raw=gtin,
+                granularity=DataCarrierIdentityLevel.ITEM,
+            )
+            await self.link_identifier_to_dpp(
+                tenant_id=dpp.tenant_id,
+                dpp_id=dpp.id,
+                external_identifier_id=identifier.id,
+            )
+            return identifier
+
+        global_asset_id = str(asset_ids.get("globalAssetId", "")).strip()
+        if global_asset_id:
+            identifier = await self.reserve_or_register(
+                tenant_id=dpp.tenant_id,
+                created_by=created_by,
+                entity_type=IdentifierEntityType.PRODUCT,
+                scheme_code="uri",
+                value_raw=global_asset_id,
+                granularity=DataCarrierIdentityLevel.ITEM,
+            )
+            await self.link_identifier_to_dpp(
+                tenant_id=dpp.tenant_id,
+                dpp_id=dpp.id,
+                external_identifier_id=identifier.id,
+            )
+            return identifier
+        return None

--- a/backend/app/standards/cen_pren/profiles.py
+++ b/backend/app/standards/cen_pren/profiles.py
@@ -1,0 +1,37 @@
+"""CEN prEN profile resolution and header helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.core.config import Settings, get_settings
+
+
+@dataclass(frozen=True)
+class CENProfiles:
+    """Resolved CEN profile versions for active standards workstreams."""
+
+    enabled: bool
+    profile_18219: str
+    profile_18220: str
+    profile_18222: str
+
+
+def get_cen_profiles(settings: Settings | None = None) -> CENProfiles:
+    """Resolve CEN profile settings from runtime configuration."""
+    cfg = settings or get_settings()
+    return CENProfiles(
+        enabled=cfg.cen_dpp_enabled,
+        profile_18219=cfg.cen_profile_18219,
+        profile_18220=cfg.cen_profile_18220,
+        profile_18222=cfg.cen_profile_18222,
+    )
+
+
+def standards_profile_header(profiles: CENProfiles) -> str:
+    """Serialize CEN profile versions for API response headers."""
+    return (
+        f"CEN-{profiles.profile_18219};"
+        f"CEN-{profiles.profile_18220};"
+        f"CEN-{profiles.profile_18222}"
+    )

--- a/backend/app/standards/cen_pren/profiles.py
+++ b/backend/app/standards/cen_pren/profiles.py
@@ -30,8 +30,4 @@ def get_cen_profiles(settings: Settings | None = None) -> CENProfiles:
 
 def standards_profile_header(profiles: CENProfiles) -> str:
     """Serialize CEN profile versions for API response headers."""
-    return (
-        f"CEN-{profiles.profile_18219};"
-        f"CEN-{profiles.profile_18220};"
-        f"CEN-{profiles.profile_18222}"
-    )
+    return f"CEN-{profiles.profile_18219};CEN-{profiles.profile_18220};CEN-{profiles.profile_18222}"

--- a/backend/tests/unit/test_cen_api_openapi.py
+++ b/backend/tests/unit/test_cen_api_openapi.py
@@ -1,0 +1,43 @@
+"""OpenAPI contract checks for CEN facade route registration."""
+
+from __future__ import annotations
+
+from app.core.config import get_settings
+from app.main import create_application
+
+
+def test_cen_routes_not_mounted_when_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("CEN_DPP_ENABLED", "false")
+    get_settings.cache_clear()
+    app = create_application()
+    paths = set(app.openapi()["paths"].keys())
+    assert "/api/v1/tenants/{tenant_slug}/cen/dpps" not in paths
+    assert "/api/v1/public/{tenant_slug}/cen/dpps" not in paths
+    get_settings.cache_clear()
+
+
+def test_cen_operation_ids_when_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("CEN_DPP_ENABLED", "true")
+    get_settings.cache_clear()
+    app = create_application()
+    openapi = app.openapi()
+    operation_ids = {
+        operation["operationId"]
+        for methods in openapi["paths"].values()
+        for operation in methods.values()
+        if isinstance(operation, dict) and "operationId" in operation
+    }
+    assert {
+        "CreateDPP",
+        "ReadDPPById",
+        "SearchDPPs",
+        "ReadDPPByIdentifier",
+        "UpdateDPP",
+        "ArchiveDPP",
+        "PublishDPP",
+        "ValidateIdentifier",
+        "SupersedeIdentifier",
+        "SyncRegistryForDPP",
+        "SyncResolverForDPP",
+    }.issubset(operation_ids)
+    get_settings.cache_clear()

--- a/backend/tests/unit/test_cen_api_service.py
+++ b/backend/tests/unit/test_cen_api_service.py
@@ -1,0 +1,77 @@
+"""Unit tests for CEN API service lifecycle and immutability behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.db.models import DPPStatus, IdentifierEntityType
+from app.modules.cen_api.service import CENAPIConflictError, CENAPIError, CENAPIService
+
+
+def _mock_dpp(*, status: DPPStatus, asset_ids: dict[str, str]) -> MagicMock:
+    dpp = MagicMock()
+    dpp.id = uuid4()
+    dpp.tenant_id = uuid4()
+    dpp.status = status
+    dpp.asset_ids = dict(asset_ids)
+    dpp.visibility_scope = "owner_team"
+    return dpp
+
+
+@pytest.mark.asyncio
+async def test_update_published_dpp_identifier_fields_requires_supersede() -> None:
+    session = AsyncMock()
+    session.flush = AsyncMock()
+    service = CENAPIService(session)
+    service._settings.cen_dpp_enabled = False
+    dpp = _mock_dpp(status=DPPStatus.PUBLISHED, asset_ids={"gtin": "01234567890128"})
+
+    with (
+        patch.object(service, "get_dpp", AsyncMock(return_value=dpp)),
+        pytest.raises(CENAPIConflictError),
+    ):
+        await service.update_dpp(
+            tenant_id=dpp.tenant_id,
+            dpp_id=dpp.id,
+            updated_by="publisher-sub",
+            asset_ids_patch={"gtin": "01234567890129"},
+            visibility_scope=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_draft_dpp_allows_identifier_change() -> None:
+    session = AsyncMock()
+    session.flush = AsyncMock()
+    service = CENAPIService(session)
+    service._settings.cen_dpp_enabled = False
+    dpp = _mock_dpp(status=DPPStatus.DRAFT, asset_ids={"gtin": "01234567890128"})
+
+    with patch.object(service, "get_dpp", AsyncMock(return_value=dpp)):
+        updated = await service.update_dpp(
+            tenant_id=dpp.tenant_id,
+            dpp_id=dpp.id,
+            updated_by="publisher-sub",
+            asset_ids_patch={"gtin": "01234567890129"},
+            visibility_scope=None,
+        )
+
+    assert updated.asset_ids["gtin"] == "01234567890129"
+
+
+@pytest.mark.asyncio
+async def test_validate_identifier_wraps_governance_errors() -> None:
+    session = AsyncMock()
+    service = CENAPIService(session)
+    service._identifier_service._settings.cen_allow_http_identifiers = False
+
+    with pytest.raises(CENAPIError):
+        await service.validate_identifier(
+            entity_type=IdentifierEntityType.PRODUCT,
+            scheme_code="uri",
+            value_raw="http://example.com/id",
+            granularity=None,
+        )

--- a/backend/tests/unit/test_cen_profiles.py
+++ b/backend/tests/unit/test_cen_profiles.py
@@ -1,0 +1,17 @@
+"""Tests for CEN profile helpers."""
+
+from __future__ import annotations
+
+from app.standards.cen_pren.profiles import CENProfiles, standards_profile_header
+
+
+def test_standards_profile_header_serialization() -> None:
+    profiles = CENProfiles(
+        enabled=True,
+        profile_18219="prEN18219:2025-07",
+        profile_18220="prEN18220:2025-07",
+        profile_18222="prEN18222:2025-07",
+    )
+    assert standards_profile_header(profiles) == (
+        "CEN-prEN18219:2025-07;CEN-prEN18220:2025-07;CEN-prEN18222:2025-07"
+    )

--- a/backend/tests/unit/test_data_carrier_cen.py
+++ b/backend/tests/unit/test_data_carrier_cen.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from uuid import uuid4
 
+import pytest
+
+from app.db.models import DataCarrierStatus as DataCarrierStatusDB
+from app.db.models import DataCarrierType as DataCarrierTypeDB
 from app.modules.data_carriers.schemas import (
     DataCarrierLayoutProfile,
     DataCarrierType,
@@ -54,3 +60,63 @@ def test_preflight_returns_qr_profile_details() -> None:
     assert response.valid is True
     assert response.details["error_correction"] == "Q"
     assert response.details["quiet_zone_modules"] == 2
+
+
+@pytest.mark.asyncio
+async def test_qa_report_detects_qr_layout_anomalies() -> None:
+    service = DataCarrierService(AsyncMock())
+    carrier = SimpleNamespace(
+        id=uuid4(),
+        encoded_uri="https://example.com/carrier",
+        status=DataCarrierStatusDB.ACTIVE,
+        carrier_type=DataCarrierTypeDB.QR,
+        layout_profile={"error_correction": "X", "quiet_zone_modules": 20},
+    )
+    service.get_carrier = AsyncMock(return_value=carrier)  # type: ignore[method-assign]
+
+    report = await service.build_qa_report(carrier_id=carrier.id, tenant_id=uuid4())
+    checks = {check.check_type: check for check in report.checks}
+
+    assert checks["qr_error_correction"].passed is False
+    assert checks["qr_error_correction"].severity == "error"
+    assert checks["qr_quiet_zone"].passed is False
+    assert checks["qr_quiet_zone"].severity == "warning"
+
+
+@pytest.mark.asyncio
+async def test_qa_report_flags_datamatrix_runtime_unavailable() -> None:
+    service = DataCarrierService(AsyncMock())
+    carrier = SimpleNamespace(
+        id=uuid4(),
+        encoded_uri="https://example.com/carrier",
+        status=DataCarrierStatusDB.ACTIVE,
+        carrier_type=DataCarrierTypeDB.DATAMATRIX,
+        layout_profile={},
+    )
+    service.get_carrier = AsyncMock(return_value=carrier)  # type: ignore[method-assign]
+    service._datamatrix_renderer.is_available = lambda: False
+
+    report = await service.build_qa_report(carrier_id=carrier.id, tenant_id=uuid4())
+    checks = {check.check_type: check for check in report.checks}
+
+    assert checks["datamatrix_runtime"].passed is False
+    assert checks["datamatrix_runtime"].severity == "warning"
+
+
+@pytest.mark.asyncio
+async def test_qa_report_flags_nfc_capacity_overflow() -> None:
+    service = DataCarrierService(AsyncMock())
+    carrier = SimpleNamespace(
+        id=uuid4(),
+        encoded_uri="https://example.com/" + ("x" * 120),
+        status=DataCarrierStatusDB.ACTIVE,
+        carrier_type=DataCarrierTypeDB.NFC,
+        layout_profile={"nfc_memory_bytes": 24},
+    )
+    service.get_carrier = AsyncMock(return_value=carrier)  # type: ignore[method-assign]
+
+    report = await service.build_qa_report(carrier_id=carrier.id, tenant_id=uuid4())
+    checks = {check.check_type: check for check in report.checks}
+
+    assert checks["nfc_capacity"].passed is False
+    assert checks["nfc_capacity"].severity == "error"

--- a/backend/tests/unit/test_data_carrier_cen.py
+++ b/backend/tests/unit/test_data_carrier_cen.py
@@ -1,0 +1,56 @@
+"""Unit tests for CEN data-carrier preflight behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from app.modules.data_carriers.schemas import (
+    DataCarrierLayoutProfile,
+    DataCarrierType,
+    DataCarrierValidationRequest,
+)
+from app.modules.data_carriers.service import DataCarrierService
+
+
+def test_preflight_reports_datamatrix_runtime_unavailable(monkeypatch) -> None:
+    service = DataCarrierService(AsyncMock())
+    monkeypatch.setattr(service._datamatrix_renderer, "is_available", lambda: False)
+
+    response = service.validate_payload_preflight(
+        request=DataCarrierValidationRequest(
+            carrier_type=DataCarrierType.DATAMATRIX,
+            payload="https://example.com/dpp/123",
+        )
+    )
+
+    assert response.valid is False
+    assert response.details.get("runtime_available") is False
+    assert any("DataMatrix renderer unavailable" in warning for warning in response.warnings)
+
+
+def test_preflight_enforces_nfc_memory_limit() -> None:
+    service = DataCarrierService(AsyncMock())
+    response = service.validate_payload_preflight(
+        request=DataCarrierValidationRequest(
+            carrier_type=DataCarrierType.NFC,
+            payload="https://example.com/" + ("x" * 80),
+            layout_profile=DataCarrierLayoutProfile(nfc_memory_bytes=32),
+        )
+    )
+    assert response.valid is False
+    assert any("exceeds configured memory" in warning for warning in response.warnings)
+
+
+def test_preflight_returns_qr_profile_details() -> None:
+    service = DataCarrierService(AsyncMock())
+    response = service.validate_payload_preflight(
+        request=DataCarrierValidationRequest(
+            carrier_type=DataCarrierType.QR,
+            payload="https://example.com/dpp/123",
+            layout_profile=DataCarrierLayoutProfile(error_correction="Q", quiet_zone_modules=2),
+        )
+    )
+
+    assert response.valid is True
+    assert response.details["error_correction"] == "Q"
+    assert response.details["quiet_zone_modules"] == 2

--- a/backend/tests/unit/test_identifiers.py
+++ b/backend/tests/unit/test_identifiers.py
@@ -37,3 +37,19 @@ def test_build_global_asset_id_uses_normalized_base() -> None:
     asset_ids = {"manufacturerPartId": "PART-123", "serialNumber": "SN-456"}
     result = build_global_asset_id("http://example.org/asset", asset_ids)
     assert result == "http://example.org/asset/PART-123--SN-456"
+
+
+def test_build_global_asset_id_allows_https_when_configured() -> None:
+    asset_ids = {"manufacturerPartId": "PART-123", "serialNumber": "SN-456"}
+    result = build_global_asset_id(
+        "https://example.org/asset",
+        asset_ids,
+        allowed_schemes={"https"},
+    )
+    assert result == "https://example.org/asset/PART-123--SN-456"
+
+
+def test_build_global_asset_id_rejects_https_without_override() -> None:
+    asset_ids = {"manufacturerPartId": "PART-123", "serialNumber": "SN-456"}
+    with pytest.raises(IdentifierValidationError):
+        build_global_asset_id("https://example.org/asset", asset_ids)

--- a/backend/tests/unit/test_tenant_rls_coverage.py
+++ b/backend/tests/unit/test_tenant_rls_coverage.py
@@ -84,6 +84,17 @@ _RLS_0036 = {
     "dataspace_publication_jobs",
 }
 
+# Tables with RLS from migrations 0041-0043
+_RLS_0041_0043 = {
+    "external_identifiers",
+    "dpp_identifiers",
+    "economic_operators",
+    "facilities",
+    "operator_identifiers",
+    "facility_identifiers",
+    "data_carrier_quality_checks",
+}
+
 TABLES_WITH_RLS = (
     _RLS_0005
     | _RLS_0008_0009
@@ -95,6 +106,7 @@ TABLES_WITH_RLS = (
     | _RLS_0029
     | _RLS_0035
     | _RLS_0036
+    | _RLS_0041_0043
 )
 
 

--- a/backend/tools/backfill_cen_identifiers.py
+++ b/backend/tools/backfill_cen_identifiers.py
@@ -1,0 +1,205 @@
+"""Backfill CEN canonical identifiers and carrier bindings for existing DPPs."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import (
+    DPP,
+    DataCarrier,
+    DPPIdentifier,
+    ExternalIdentifier,
+    ExternalIdentifierStatus,
+    IdentifierEntityType,
+)
+from app.db.session import close_db, get_background_session, init_db
+from app.standards.cen_pren.identifiers_18219.service import IdentifierService
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill canonical CEN identifiers for existing DPPs and carriers."
+    )
+    parser.add_argument(
+        "--tenant-id",
+        help="Single tenant UUID to process. Omit when using --all-tenants.",
+    )
+    parser.add_argument(
+        "--all-tenants",
+        action="store_true",
+        help="Process every tenant that has at least one DPP.",
+    )
+    parser.add_argument(
+        "--limit-per-tenant",
+        type=int,
+        default=None,
+        help="Optional cap on number of DPPs processed per tenant.",
+    )
+    parser.add_argument(
+        "--skip-carrier-linking",
+        action="store_true",
+        help="Skip data-carrier external identifier/payload hash backfill.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Execute and report changes without committing.",
+    )
+    return parser.parse_args()
+
+
+async def _resolve_tenant_ids(
+    *,
+    tenant_id_arg: str | None,
+    all_tenants: bool,
+) -> list[UUID]:
+    if tenant_id_arg:
+        return [UUID(tenant_id_arg)]
+    if not all_tenants:
+        raise ValueError("Provide --tenant-id or --all-tenants")
+
+    async with get_background_session() as session:
+        result = await session.execute(select(DPP.tenant_id).distinct())
+        return [tenant_id for tenant_id in result.scalars().all() if tenant_id is not None]
+
+
+async def _get_active_product_identifier_id(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    dpp_id: UUID,
+) -> UUID | None:
+    result = await session.execute(
+        select(ExternalIdentifier.id)
+        .join(DPPIdentifier, DPPIdentifier.external_identifier_id == ExternalIdentifier.id)
+        .where(
+            DPPIdentifier.tenant_id == tenant_id,
+            DPPIdentifier.dpp_id == dpp_id,
+            ExternalIdentifier.tenant_id == tenant_id,
+            ExternalIdentifier.entity_type == IdentifierEntityType.PRODUCT,
+            ExternalIdentifier.status == ExternalIdentifierStatus.ACTIVE,
+        )
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _process_tenant(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    limit_per_tenant: int | None,
+    link_carriers: bool,
+) -> dict[str, int]:
+    service = IdentifierService(session)
+    counters: dict[str, int] = {
+        "dpps_scanned": 0,
+        "dpps_with_existing_identifier": 0,
+        "identifiers_registered": 0,
+        "dpps_without_identifier_source": 0,
+        "carriers_scanned": 0,
+        "carriers_identifier_linked": 0,
+        "carriers_payload_hashed": 0,
+    }
+
+    stmt = select(DPP).where(DPP.tenant_id == tenant_id).order_by(DPP.id)
+    if limit_per_tenant is not None:
+        stmt = stmt.limit(limit_per_tenant)
+    dpps = (await session.execute(stmt)).scalars().all()
+
+    for dpp in dpps:
+        counters["dpps_scanned"] += 1
+        has_identifier = await service.has_active_product_identifier(
+            tenant_id=tenant_id,
+            dpp_id=dpp.id,
+        )
+        if has_identifier:
+            counters["dpps_with_existing_identifier"] += 1
+        else:
+            identifier = await service.ensure_dpp_product_identifier_from_asset_ids(
+                dpp=dpp,
+                created_by=dpp.owner_subject,
+            )
+            if identifier is None:
+                counters["dpps_without_identifier_source"] += 1
+            else:
+                counters["identifiers_registered"] += 1
+
+        if not link_carriers:
+            continue
+
+        active_identifier_id = await _get_active_product_identifier_id(
+            session,
+            tenant_id=tenant_id,
+            dpp_id=dpp.id,
+        )
+        carriers = (
+            await session.execute(
+                select(DataCarrier).where(
+                    DataCarrier.tenant_id == tenant_id,
+                    DataCarrier.dpp_id == dpp.id,
+                )
+            )
+        ).scalars().all()
+        for carrier in carriers:
+            counters["carriers_scanned"] += 1
+            if active_identifier_id is not None and carrier.external_identifier_id is None:
+                carrier.external_identifier_id = active_identifier_id
+                counters["carriers_identifier_linked"] += 1
+            if carrier.encoded_uri and not carrier.payload_sha256:
+                carrier.payload_sha256 = hashlib.sha256(
+                    carrier.encoded_uri.encode("utf-8")
+                ).hexdigest()
+                counters["carriers_payload_hashed"] += 1
+
+    return counters
+
+
+async def _main() -> int:
+    args = _parse_args()
+    await init_db()
+    try:
+        tenant_ids = await _resolve_tenant_ids(
+            tenant_id_arg=args.tenant_id,
+            all_tenants=args.all_tenants,
+        )
+        summary: dict[str, object] = {
+            "ran_at": datetime.now(UTC).isoformat(),
+            "dry_run": args.dry_run,
+            "tenant_count": len(tenant_ids),
+            "processed": [],
+            "errors": [],
+        }
+        for tenant_id in tenant_ids:
+            try:
+                async with get_background_session() as session:
+                    counters = await _process_tenant(
+                        session,
+                        tenant_id=tenant_id,
+                        limit_per_tenant=args.limit_per_tenant,
+                        link_carriers=not args.skip_carrier_linking,
+                    )
+                    if args.dry_run:
+                        await session.rollback()
+                    else:
+                        await session.commit()
+                    summary["processed"].append({"tenant_id": str(tenant_id), **counters})
+            except Exception as exc:  # pragma: no cover - defensive
+                summary["errors"].append({"tenant_id": str(tenant_id), "error": str(exc)})
+
+        print(json.dumps(summary, indent=2))
+        return 0 if not summary["errors"] else 1
+    finally:
+        await close_db()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/backend/tools/backfill_cen_identifiers.py
+++ b/backend/tools/backfill_cen_identifiers.py
@@ -142,13 +142,17 @@ async def _process_tenant(
             dpp_id=dpp.id,
         )
         carriers = (
-            await session.execute(
-                select(DataCarrier).where(
-                    DataCarrier.tenant_id == tenant_id,
-                    DataCarrier.dpp_id == dpp.id,
+            (
+                await session.execute(
+                    select(DataCarrier).where(
+                        DataCarrier.tenant_id == tenant_id,
+                        DataCarrier.dpp_id == dpp.id,
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         for carrier in carriers:
             counters["carriers_scanned"] += 1
             if active_identifier_id is not None and carrier.external_identifier_id is None:

--- a/docs/public/operations/README.md
+++ b/docs/public/operations/README.md
@@ -171,3 +171,4 @@ TEST_DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5433/dpp_insp
 - Architecture: [`../architecture/README.md`](../architecture/README.md)
 - Release guide: [`../releases/release-guide.md`](../releases/release-guide.md)
 - Public data policy: [`public-data-exposure-policy.md`](public-data-exposure-policy.md)
+- CEN prEN rollout: [`cen-pren-rollout.md`](cen-pren-rollout.md)

--- a/docs/public/operations/cen-pren-rollout.md
+++ b/docs/public/operations/cen-pren-rollout.md
@@ -1,0 +1,76 @@
+# CEN prEN Rollout Guide (18219/18220/18222)
+
+This runbook covers safe rollout of the CEN draft compliance layer.
+
+## 1. Deploy migrations with CEN disabled
+
+Keep CEN feature flags off while applying schema changes:
+
+- `CEN_DPP_ENABLED=false`
+- Keep existing routes and behavior unchanged during migration.
+
+Apply migrations:
+
+```bash
+cd backend
+uv run alembic upgrade head
+```
+
+## 2. Run identifier/carrier backfill
+
+Backfill canonical identifiers for existing DPPs and link/hash carriers where possible.
+
+Dry run first:
+
+```bash
+cd backend
+uv run python tools/backfill_cen_identifiers.py --all-tenants --dry-run
+```
+
+Apply changes:
+
+```bash
+cd backend
+uv run python tools/backfill_cen_identifiers.py --all-tenants
+```
+
+Optional scope controls:
+
+- `--tenant-id <uuid>`
+- `--limit-per-tenant <n>`
+- `--skip-carrier-linking`
+
+## 3. Enable in staging
+
+Enable CEN in staging only after migration + backfill:
+
+- `CEN_DPP_ENABLED=true`
+- `CEN_PROFILE_18219=prEN18219:2025-07`
+- `CEN_PROFILE_18220=prEN18220:2025-07`
+- `CEN_PROFILE_18222=prEN18222:2025-07`
+- `CEN_ALLOW_HTTP_IDENTIFIERS=false` (recommended default)
+
+Run validation suites in staging:
+
+```bash
+cd backend
+uv run pytest tests/unit/test_cen_api_openapi.py tests/unit/test_cen_api_service.py tests/unit/test_data_carrier_cen.py -q
+```
+
+## 4. Production phased enablement
+
+Roll out in this order:
+
+1. Enable CEN read/search facade routes first.
+2. Monitor CEN route usage and validation errors.
+3. Enable strict publish identifier gate and supersede enforcement after backfill verification.
+4. Enable DataMatrix rendering only on runtimes where dependency health checks pass.
+
+## 5. Operational checks
+
+Confirm:
+
+- CEN routes return `X-Standards-Profile` header.
+- Public CEN endpoints return published-only filtered payloads.
+- DataMatrix render returns deterministic `501` when dependency is unavailable.
+- Backfill summary shows no unexpected tenant errors.

--- a/docs/public/operations/cen-pren-rollout.md
+++ b/docs/public/operations/cen-pren-rollout.md
@@ -16,6 +16,9 @@ cd backend
 uv run alembic upgrade head
 ```
 
+Operational note: migration `0044_cen_search_indexes` creates additional indexes.
+Run this step in a low-traffic window to minimize lock impact.
+
 ## 2. Run identifier/carrier backfill
 
 Backfill canonical identifiers for existing DPPs and link/hash carriers where possible.
@@ -74,3 +77,4 @@ Confirm:
 - Public CEN endpoints return published-only filtered payloads.
 - DataMatrix render returns deterministic `501` when dependency is unavailable.
 - Backfill summary shows no unexpected tenant errors.
+- OPA policy bundle reload completed after deployment.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -39,6 +39,13 @@ export interface paths {
      */
     get: operations["get_published_dpp_api_v1_public__tenant_slug__dpps__dpp_id__get"];
   };
+  "/api/v1/public/{tenant_slug}/dpps/{dpp_id}/integrity": {
+    /**
+     * Get Public Dpp Integrity Bundle
+     * @description Return integrity metadata for external digest/signature verification.
+     */
+    get: operations["get_public_dpp_integrity_bundle_api_v1_public__tenant_slug__dpps__dpp_id__integrity_get"];
+  };
   "/api/v1/public/{tenant_slug}/dpps/slug/{slug}": {
     /**
      * Get Published Dpp By Slug
@@ -160,6 +167,13 @@ export interface paths {
      */
     get: operations["resolver_description_api_v1_resolve__well_known_gs1resolver_get"];
   };
+  "/api/v1/public/.well-known/jwks.json": {
+    /**
+     * Get Public Jwks
+     * @description Return JWKS for public signature verification.
+     */
+    get: operations["get_public_jwks_api_v1_public__well_known_jwks_json_get"];
+  };
   "/api/v1/public/{tenant_slug}/.well-known/did.json": {
     /**
      * Get Did Document
@@ -175,6 +189,115 @@ export interface paths {
      * @description Publicly verify a Verifiable Credential (no auth required).
      */
     post: operations["public_verify_credential_api_v1_public_credentials_verify_post"];
+  };
+  "/api/v1/public/cirpass/stories/latest": {
+    /**
+     * Get Latest Cirpass Stories
+     * @description Get latest CIRPASS user-story feed with stale-while-refresh behavior.
+     */
+    get: operations["get_latest_cirpass_stories_api_v1_public_cirpass_stories_latest_get"];
+  };
+  "/api/v1/public/cirpass/lab/manifest/latest": {
+    /**
+     * Get Latest Cirpass Lab Manifest
+     * @description Get latest validated CIRPASS lab scenario manifest.
+     */
+    get: operations["get_latest_cirpass_lab_manifest_api_v1_public_cirpass_lab_manifest_latest_get"];
+  };
+  "/api/v1/public/cirpass/lab/manifest/{manifest_version}": {
+    /**
+     * Get Cirpass Lab Manifest Version
+     * @description Get specific CIRPASS lab manifest version.
+     */
+    get: operations["get_cirpass_lab_manifest_version_api_v1_public_cirpass_lab_manifest__manifest_version__get"];
+  };
+  "/api/v1/public/cirpass/session": {
+    /**
+     * Create Cirpass Session
+     * @description Create anonymous signed browser session for public leaderboard submissions.
+     */
+    post: operations["create_cirpass_session_api_v1_public_cirpass_session_post"];
+  };
+  "/api/v1/public/cirpass/leaderboard": {
+    /**
+     * Get Cirpass Leaderboard
+     * @description Read public leaderboard rows for a CIRPASS story version.
+     */
+    get: operations["get_cirpass_leaderboard_api_v1_public_cirpass_leaderboard_get"];
+  };
+  "/api/v1/public/cirpass/leaderboard/submit": {
+    /**
+     * Submit Cirpass Leaderboard Score
+     * @description Submit a pseudonymous public score for the CIRPASS simulator.
+     */
+    post: operations["submit_cirpass_leaderboard_score_api_v1_public_cirpass_leaderboard_submit_post"];
+  };
+  "/api/v1/public/cirpass/lab/events": {
+    /**
+     * Ingest Cirpass Lab Event
+     * @description Ingest anonymized CIRPASS lab telemetry events.
+     */
+    post: operations["ingest_cirpass_lab_event_api_v1_public_cirpass_lab_events_post"];
+  };
+  "/api/v1/public/landing/regulatory-timeline": {
+    /**
+     * Get Public Regulatory Timeline
+     * @description Get latest verified public timeline with stale-while-refresh behavior.
+     */
+    get: operations["get_public_regulatory_timeline_api_v1_public_landing_regulatory_timeline_get"];
+  };
+  "/api/v1/public/smt/templates": {
+    /** List Public Templates */
+    get: operations["list_public_templates_api_v1_public_smt_templates_get"];
+  };
+  "/api/v1/public/smt/templates/{template_key}": {
+    /** Get Public Template */
+    get: operations["get_public_template_api_v1_public_smt_templates__template_key__get"];
+  };
+  "/api/v1/public/smt/templates/{template_key}/versions": {
+    /** List Public Template Versions */
+    get: operations["list_public_template_versions_api_v1_public_smt_templates__template_key__versions_get"];
+  };
+  "/api/v1/public/smt/templates/{template_key}/contract": {
+    /** Get Public Template Contract */
+    get: operations["get_public_template_contract_api_v1_public_smt_templates__template_key__contract_get"];
+  };
+  "/api/v1/public/smt/preview": {
+    /** Preview Public Template Instance */
+    post: operations["preview_public_template_instance_api_v1_public_smt_preview_post"];
+  };
+  "/api/v1/public/smt/export": {
+    /** Export Public Template Instance */
+    post: operations["export_public_template_instance_api_v1_public_smt_export_post"];
+  };
+  "/api/v1/public/{tenant_slug}/cen/dpps/{dpp_id}": {
+    /** Public Read Dpp By Id */
+    get: operations["PublicReadDPPById"];
+  };
+  "/api/v1/public/{tenant_slug}/cen/dpps": {
+    /** Public Search Dpps */
+    get: operations["PublicSearchDPPs"];
+  };
+  "/api/v1/lab/reset": {
+    /**
+     * Reset Lab State
+     * @description Reset lab tenant fixtures to deterministic baseline (admin only).
+     */
+    post: operations["reset_lab_state_api_v1_lab_reset_post"];
+  };
+  "/api/v1/lab/seed": {
+    /**
+     * Seed Lab State
+     * @description Seed deterministic fixtures required by a specific scenario (admin only).
+     */
+    post: operations["seed_lab_state_api_v1_lab_seed_post"];
+  };
+  "/api/v1/lab/status": {
+    /**
+     * Get Lab Status
+     * @description Inspect current deterministic sandbox state for live-mode readiness.
+     */
+    get: operations["get_lab_status_api_v1_lab_status_get"];
   };
   "/api/v1/onboarding/status": {
     /**
@@ -322,6 +445,13 @@ export interface paths {
      * Requires publisher role.
      */
     post: operations["refresh_template_api_v1_templates_refresh__template_key__post"];
+  };
+  "/api/v1/templates/catalog/sync": {
+    /**
+     * Sync Template Catalog
+     * @description Sync published/deprecated IDTA templates into DB cache (authenticated).
+     */
+    post: operations["sync_template_catalog_api_v1_templates_catalog_sync_post"];
   };
   "/api/v1/tenants/{tenant_slug}/dpps": {
     /**
@@ -486,6 +616,13 @@ export interface paths {
      * @description Compare two revisions of a DPP.
      */
     get: operations["diff_revisions_api_v1_tenants__tenant_slug__dpps__dpp_id__diff_get"];
+  };
+  "/api/v1/tenants/{tenant_slug}/dpps/{dpp_id}/digital-link": {
+    /**
+     * Get GS1 Digital Link URI for a DPP
+     * @description Return the canonical GS1 Digital Link URI for a DPP with GTIN.
+     */
+    get: operations["get_dpp_digital_link_api_v1_tenants__tenant_slug__dpps__dpp_id__digital_link_get"];
   };
   "/api/v1/tenants/{tenant_slug}/masters": {
     /** List Masters */
@@ -911,6 +1048,18 @@ export interface paths {
     /** Render Data Carrier */
     post: operations["render_data_carrier_api_v1_tenants__tenant_slug__data_carriers__carrier_id__render_post"];
   };
+  "/api/v1/tenants/{tenant_slug}/data-carriers/validate": {
+    /** Validate Data Carrier Payload */
+    post: operations["validate_data_carrier_payload_api_v1_tenants__tenant_slug__data_carriers_validate_post"];
+  };
+  "/api/v1/tenants/{tenant_slug}/data-carriers/{carrier_id}/qa": {
+    /** Get Data Carrier Qa */
+    get: operations["get_data_carrier_qa_api_v1_tenants__tenant_slug__data_carriers__carrier_id__qa_get"];
+  };
+  "/api/v1/tenants/{tenant_slug}/data-carriers/{carrier_id}/quality-checks": {
+    /** Create Data Carrier Quality Check */
+    post: operations["create_data_carrier_quality_check_api_v1_tenants__tenant_slug__data_carriers__carrier_id__quality_checks_post"];
+  };
   "/api/v1/tenants/{tenant_slug}/data-carriers/{carrier_id}/lifecycle/deprecate": {
     /** Deprecate Data Carrier */
     post: operations["deprecate_data_carrier_api_v1_tenants__tenant_slug__data_carriers__carrier_id__lifecycle_deprecate_post"];
@@ -930,6 +1079,78 @@ export interface paths {
   "/api/v1/tenants/{tenant_slug}/data-carriers/registry-export": {
     /** Export Registry */
     get: operations["export_registry_api_v1_tenants__tenant_slug__data_carriers_registry_export_get"];
+  };
+  "/api/v1/tenants/{tenant_slug}/identifiers/validate": {
+    /** Validate Identifier */
+    post: operations["validate_identifier_api_v1_tenants__tenant_slug__identifiers_validate_post"];
+  };
+  "/api/v1/tenants/{tenant_slug}/identifiers": {
+    /** List Identifiers */
+    get: operations["list_identifiers_api_v1_tenants__tenant_slug__identifiers_get"];
+    /** Register Identifier */
+    post: operations["register_identifier_api_v1_tenants__tenant_slug__identifiers_post"];
+  };
+  "/api/v1/tenants/{tenant_slug}/identifiers/{identifier_id}": {
+    /** Get Identifier */
+    get: operations["get_identifier_api_v1_tenants__tenant_slug__identifiers__identifier_id__get"];
+  };
+  "/api/v1/tenants/{tenant_slug}/identifiers/{identifier_id}/supersede": {
+    /** Supersede Identifier */
+    post: operations["supersede_identifier_api_v1_tenants__tenant_slug__identifiers__identifier_id__supersede_post"];
+  };
+  "/api/v1/tenants/{tenant_slug}/identifiers/operators": {
+    /** List Operators */
+    get: operations["list_operators_api_v1_tenants__tenant_slug__identifiers_operators_get"];
+    /** Create Operator */
+    post: operations["create_operator_api_v1_tenants__tenant_slug__identifiers_operators_post"];
+  };
+  "/api/v1/tenants/{tenant_slug}/identifiers/facilities": {
+    /** List Facilities */
+    get: operations["list_facilities_api_v1_tenants__tenant_slug__identifiers_facilities_get"];
+    /** Create Facility */
+    post: operations["create_facility_api_v1_tenants__tenant_slug__identifiers_facilities_post"];
+  };
+  "/api/v1/tenants/{tenant_slug}/cen/dpps": {
+    /** Search Dpps */
+    get: operations["SearchDPPs"];
+    /** Create Dpp */
+    post: operations["CreateDPP"];
+  };
+  "/api/v1/tenants/{tenant_slug}/cen/dpps/{dpp_id}": {
+    /** Read Dpp By Id */
+    get: operations["ReadDPPById"];
+    /** Archive Dpp */
+    delete: operations["ArchiveDPP"];
+    /** Update Dpp */
+    patch: operations["UpdateDPP"];
+  };
+  "/api/v1/tenants/{tenant_slug}/cen/dpps/by-identifier": {
+    /** Read Dpp By Identifier */
+    get: operations["ReadDPPByIdentifier"];
+  };
+  "/api/v1/tenants/{tenant_slug}/cen/dpps/{dpp_id}/publish": {
+    /** Publish Dpp */
+    post: operations["PublishDPP"];
+  };
+  "/api/v1/tenants/{tenant_slug}/cen/identifiers/validate": {
+    /** Validate Identifier */
+    post: operations["ValidateIdentifier"];
+  };
+  "/api/v1/tenants/{tenant_slug}/cen/identifiers": {
+    /** Register Identifier */
+    post: operations["RegisterIdentifier"];
+  };
+  "/api/v1/tenants/{tenant_slug}/cen/identifiers/{identifier_id}/supersede": {
+    /** Supersede Identifier */
+    post: operations["SupersedeIdentifier"];
+  };
+  "/api/v1/tenants/{tenant_slug}/cen/registrations/dpps/{dpp_id}": {
+    /** Sync Registry For Dpp */
+    post: operations["SyncRegistryForDPP"];
+  };
+  "/api/v1/tenants/{tenant_slug}/cen/resolutions/dpps/{dpp_id}": {
+    /** Sync Resolver For Dpp */
+    post: operations["SyncResolverForDPP"];
   };
   "/api/v1/admin/settings/global-asset-id-base-uri": {
     /**
@@ -958,6 +1179,13 @@ export interface paths {
      * @description Update data carrier compliance profile and publish gate setting.
      */
     put: operations["update_data_carrier_compliance_settings_api_v1_admin_settings_data_carrier_compliance_put"];
+  };
+  "/api/v1/admin/settings/cen-profiles": {
+    /**
+     * Get Cen Profiles Diagnostics
+     * @description Return active CEN profile versions for diagnostics and contract debugging.
+     */
+    get: operations["get_cen_profiles_diagnostics_api_v1_admin_settings_cen_profiles_get"];
   };
   "/api/v1/tenants/{tenant_slug}/compliance/check/{dpp_id}": {
     /**
@@ -1018,7 +1246,7 @@ export interface paths {
   "/api/v1/admin/audit/anchor": {
     /**
      * Anchor Merkle Root
-     * @description Compute Merkle root and optionally sign it (admin only).
+     * @description Anchor the next unanchored audit batch (admin only).
      */
     post: operations["anchor_merkle_root_api_v1_admin_audit_anchor_post"];
   };
@@ -1310,6 +1538,148 @@ export interface paths {
      */
     patch: operations["review_role_request_api_v1_tenants__tenant_slug__role_requests__request_id__patch"];
   };
+  "/api/v1/tenants/{tenant_slug}/opcua/status": {
+    /**
+     * Get Opcua Feature Status
+     * @description Return whether OPC UA endpoints are enabled in this environment.
+     */
+    get: operations["get_opcua_feature_status_api_v1_tenants__tenant_slug__opcua_status_get"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/sources": {
+    /**
+     * List Sources
+     * @description List OPC UA sources for the current tenant.
+     */
+    get: operations["list_sources_api_v1_tenants__tenant_slug__opcua_sources_get"];
+    /**
+     * Create Source
+     * @description Register a new OPC UA source.
+     */
+    post: operations["create_source_api_v1_tenants__tenant_slug__opcua_sources_post"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/sources/{source_id}": {
+    /**
+     * Get Source
+     * @description Get details of a single OPC UA source (password never exposed).
+     */
+    get: operations["get_source_api_v1_tenants__tenant_slug__opcua_sources__source_id__get"];
+    /**
+     * Delete Source
+     * @description Delete an OPC UA source and all related nodesets/mappings.
+     */
+    delete: operations["delete_source_api_v1_tenants__tenant_slug__opcua_sources__source_id__delete"];
+    /**
+     * Update Source
+     * @description Update an existing OPC UA source.
+     */
+    patch: operations["update_source_api_v1_tenants__tenant_slug__opcua_sources__source_id__patch"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/sources/{source_id}/test-connection": {
+    /**
+     * Test Connection
+     * @description Test connectivity to an OPC UA endpoint (3s timeout).
+     */
+    post: operations["test_connection_api_v1_tenants__tenant_slug__opcua_sources__source_id__test_connection_post"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/nodesets": {
+    /**
+     * List Nodesets
+     * @description List uploaded NodeSets, optionally filtered by source.
+     */
+    get: operations["list_nodesets_api_v1_tenants__tenant_slug__opcua_nodesets_get"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/nodesets/upload": {
+    /**
+     * Upload Nodeset
+     * @description Upload a NodeSet2.xml, parse it, and store metadata + file.
+     */
+    post: operations["upload_nodeset_api_v1_tenants__tenant_slug__opcua_nodesets_upload_post"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/nodesets/{nodeset_id}": {
+    /**
+     * Get Nodeset
+     * @description Get full detail of a NodeSet including parsed node graph.
+     */
+    get: operations["get_nodeset_api_v1_tenants__tenant_slug__opcua_nodesets__nodeset_id__get"];
+    /**
+     * Delete Nodeset
+     * @description Delete a NodeSet from DB and object storage.
+     */
+    delete: operations["delete_nodeset_api_v1_tenants__tenant_slug__opcua_nodesets__nodeset_id__delete"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/nodesets/{nodeset_id}/download": {
+    /**
+     * Download Nodeset
+     * @description Generate a presigned download URL for the NodeSet XML.
+     */
+    get: operations["download_nodeset_api_v1_tenants__tenant_slug__opcua_nodesets__nodeset_id__download_get"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/nodesets/{nodeset_id}/nodes": {
+    /**
+     * Search Nodeset Nodes
+     * @description Search the parsed node graph of a NodeSet.
+     */
+    get: operations["search_nodeset_nodes_api_v1_tenants__tenant_slug__opcua_nodesets__nodeset_id__nodes_get"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/mappings": {
+    /**
+     * List Mappings
+     * @description List OPC UA mappings with optional filters.
+     */
+    get: operations["list_mappings_api_v1_tenants__tenant_slug__opcua_mappings_get"];
+    /**
+     * Create Mapping
+     * @description Create a new OPC UA → AAS/EPCIS mapping.
+     */
+    post: operations["create_mapping_api_v1_tenants__tenant_slug__opcua_mappings_post"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/mappings/{mapping_id}": {
+    /**
+     * Get Mapping
+     * @description Get details of a single mapping.
+     */
+    get: operations["get_mapping_api_v1_tenants__tenant_slug__opcua_mappings__mapping_id__get"];
+    /**
+     * Delete Mapping
+     * @description Delete a mapping.
+     */
+    delete: operations["delete_mapping_api_v1_tenants__tenant_slug__opcua_mappings__mapping_id__delete"];
+    /**
+     * Update Mapping
+     * @description Update an existing mapping.
+     */
+    patch: operations["update_mapping_api_v1_tenants__tenant_slug__opcua_mappings__mapping_id__patch"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/mappings/{mapping_id}/validate": {
+    /**
+     * Validate Mapping
+     * @description Validate a mapping's NodeId, AAS path, SAMM URN, and transform expression.
+     */
+    post: operations["validate_mapping_api_v1_tenants__tenant_slug__opcua_mappings__mapping_id__validate_post"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/mappings/{mapping_id}/dry-run": {
+    /**
+     * Dry Run Mapping
+     * @description Preview the effect of a mapping against a DPP revision (no DB writes).
+     */
+    post: operations["dry_run_mapping_api_v1_tenants__tenant_slug__opcua_mappings__mapping_id__dry_run_post"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/dataspace/publish": {
+    /** Queue a DPP for dataspace publication */
+    post: operations["publish_to_dataspace_api_v1_tenants__tenant_slug__opcua_dataspace_publish_post"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/dataspace/jobs": {
+    /** List dataspace publication jobs */
+    get: operations["list_publication_jobs_api_v1_tenants__tenant_slug__opcua_dataspace_jobs_get"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/dataspace/jobs/{job_id}": {
+    /** Get a publication job */
+    get: operations["get_publication_job_api_v1_tenants__tenant_slug__opcua_dataspace_jobs__job_id__get"];
+  };
+  "/api/v1/tenants/{tenant_slug}/opcua/dataspace/jobs/{job_id}/retry": {
+    /** Retry a failed publication job */
+    post: operations["retry_publication_job_api_v1_tenants__tenant_slug__opcua_dataspace_jobs__job_id__retry_post"];
+  };
   "/metrics": {
     /**
      * Metrics
@@ -1367,7 +1737,7 @@ export interface components {
       id: string;
       /** Subject */
       subject?: string | null;
-      actor?: components["schemas"]["ActorSummary"] | null;
+      actor?: components["schemas"]["app__modules__activity__router__ActorSummary"] | null;
       /** Action */
       action: string;
       /** Resource Type */
@@ -1385,7 +1755,7 @@ export interface components {
     };
     /**
      * ActorSummary
-     * @description Actor metadata for activity responses.
+     * @description Actor identity summary for ownership metadata.
      */
     ActorSummary: {
       /** Subject */
@@ -1456,6 +1826,8 @@ export interface components {
      * @description Result of a Merkle anchor operation.
      */
     AnchorResponse: {
+      /** Anchor Id */
+      anchor_id?: string | null;
       /** Merkle Root */
       merkle_root: string;
       /** Event Count */
@@ -1466,6 +1838,8 @@ export interface components {
       last_sequence: number;
       /** Signature */
       signature?: string | null;
+      /** Signature Kid */
+      signature_kid?: string | null;
       /**
        * Tsa Token Present
        * @default false
@@ -1514,6 +1888,11 @@ export interface components {
       batchId?: string | null;
       /** Globalassetid */
       globalAssetId?: string | null;
+      /**
+       * Gtin
+       * @description GS1 GTIN (8/12/13/14 digits). Validated via check digit.
+       */
+      gtin?: string | null;
     };
     /**
      * AssetPublicationListResponse
@@ -1704,6 +2083,10 @@ export interface components {
       prev_event_hash?: string | null;
       /** Chain Sequence */
       chain_sequence?: number | null;
+      /** Hash Algorithm */
+      hash_algorithm?: string | null;
+      /** Hash Canonicalization */
+      hash_canonicalization?: string | null;
     };
     /** BatchExportRequest */
     BatchExportRequest: {
@@ -1883,6 +2266,15 @@ export interface components {
       /** Content Type */
       content_type?: string | null;
     };
+    /** Body_upload_nodeset_api_v1_tenants__tenant_slug__opcua_nodesets_upload_post */
+    Body_upload_nodeset_api_v1_tenants__tenant_slug__opcua_nodesets_upload_post: {
+      /**
+       * Xml File
+       * Format: binary
+       * @description NodeSet2.xml file
+       */
+      xml_file: string;
+    };
     /**
      * BulkRebuildError
      * @description Response model for rebuild errors.
@@ -1909,6 +2301,271 @@ export interface components {
       skipped: number;
       /** Errors */
       errors: components["schemas"]["BulkRebuildError"][];
+    };
+    /**
+     * CENCreateDPPRequest
+     * @description Create request for CEN facade DPP creation.
+     */
+    CENCreateDPPRequest: {
+      /** Asset Ids */
+      asset_ids?: {
+        [key: string]: unknown;
+      };
+      /** Selected Templates */
+      selected_templates?: string[];
+      /** Initial Data */
+      initial_data?: {
+        [key: string]: unknown;
+      } | null;
+      /** Required Specific Asset Ids */
+      required_specific_asset_ids?: string[] | null;
+    };
+    /**
+     * CENDPPResponse
+     * @description Canonical CEN facade DPP payload.
+     */
+    CENDPPResponse: {
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /**
+       * Platformid
+       * Format: uuid
+       */
+      platformId: string;
+      /** Status */
+      status: string;
+      /** Asset Ids */
+      asset_ids: {
+        [key: string]: unknown;
+      };
+      /** Productidentifier */
+      productIdentifier?: string | null;
+      /** Identifierscheme */
+      identifierScheme?: string | null;
+      granularity?: components["schemas"]["IdentifierGranularity"] | null;
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string;
+      /**
+       * Updated At
+       * Format: date-time
+       */
+      updated_at: string;
+    };
+    /**
+     * CENDPPSearchResponse
+     * @description CEN DPP search response contract.
+     */
+    CENDPPSearchResponse: {
+      /** Items */
+      items: components["schemas"]["CENDPPResponse"][];
+      paging: components["schemas"]["CENPaging"];
+    };
+    /**
+     * CENExternalIdentifierResponse
+     * @description Canonical identifier representation for CEN facade.
+     */
+    CENExternalIdentifierResponse: {
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /**
+       * Tenant Id
+       * Format: uuid
+       */
+      tenant_id: string;
+      entity_type: components["schemas"]["IdentifierEntityType"];
+      /** Scheme Code */
+      scheme_code: string;
+      /** Value Raw */
+      value_raw: string;
+      /** Value Canonical */
+      value_canonical: string;
+      granularity?: components["schemas"]["IdentifierGranularity"] | null;
+      /** Status */
+      status: string;
+      /** Replaced By Identifier Id */
+      replaced_by_identifier_id?: string | null;
+      /** Issued At */
+      issued_at?: string | null;
+      /** Deprecates At */
+      deprecates_at?: string | null;
+      /** Created By Subject */
+      created_by_subject: string;
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string;
+      /**
+       * Updated At
+       * Format: date-time
+       */
+      updated_at: string;
+    };
+    /**
+     * CENPaging
+     * @description Cursor-based paging metadata.
+     */
+    CENPaging: {
+      /** Cursor */
+      cursor?: string | null;
+    };
+    /**
+     * CENProfileDiagnosticsResponse
+     * @description Active CEN profile diagnostics (admin-only).
+     */
+    CENProfileDiagnosticsResponse: {
+      /** Enabled */
+      enabled: boolean;
+      /** Profile 18219 */
+      profile_18219: string;
+      /** Profile 18220 */
+      profile_18220: string;
+      /** Profile 18222 */
+      profile_18222: string;
+      /** Standards Header */
+      standards_header: string;
+    };
+    /**
+     * CENPublicDPPResponse
+     * @description Public CEN DPP payload (published-only, filtered).
+     */
+    CENPublicDPPResponse: {
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /** Status */
+      status: string;
+      /** Asset Ids */
+      asset_ids: {
+        [key: string]: unknown;
+      };
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string;
+      /**
+       * Updated At
+       * Format: date-time
+       */
+      updated_at: string;
+      /** Current Revision No */
+      current_revision_no?: number | null;
+      /** Aas Environment */
+      aas_environment?: {
+        [key: string]: unknown;
+      } | null;
+      /** Digest Sha256 */
+      digest_sha256?: string | null;
+      /** Productidentifier */
+      productIdentifier?: string | null;
+      /** Identifierscheme */
+      identifierScheme?: string | null;
+      granularity?: components["schemas"]["IdentifierGranularity"] | null;
+    };
+    /**
+     * CENRegisterIdentifierRequest
+     * @description Identifier register request.
+     */
+    CENRegisterIdentifierRequest: {
+      entity_type: components["schemas"]["IdentifierEntityType"];
+      /** Scheme Code */
+      scheme_code: string;
+      /** Value Raw */
+      value_raw: string;
+      granularity?: components["schemas"]["IdentifierGranularity"] | null;
+      /** Dpp Id */
+      dpp_id?: string | null;
+      /** Operator Id */
+      operator_id?: string | null;
+      /** Facility Id */
+      facility_id?: string | null;
+    };
+    /**
+     * CENSupersedeIdentifierRequest
+     * @description Supersede request payload.
+     */
+    CENSupersedeIdentifierRequest: {
+      /**
+       * Replacement Identifier Id
+       * Format: uuid
+       */
+      replacement_identifier_id: string;
+    };
+    /**
+     * CENSyncResponse
+     * @description Deterministic sync operation result payload.
+     */
+    CENSyncResponse: {
+      /**
+       * Dpp Id
+       * Format: uuid
+       */
+      dpp_id: string;
+      /** Synced */
+      synced: boolean;
+      /**
+       * Target
+       * @enum {string}
+       */
+      target: "registry" | "resolver";
+      /** Detail */
+      detail?: string | null;
+    };
+    /**
+     * CENUpdateDPPRequest
+     * @description Partial update payload for CEN facade DPP updates.
+     */
+    CENUpdateDPPRequest: {
+      /** Asset Ids */
+      asset_ids?: {
+        [key: string]: unknown;
+      } | null;
+      /** Visibility Scope */
+      visibility_scope?: ("owner_team" | "tenant") | null;
+    };
+    /**
+     * CENValidateIdentifierRequest
+     * @description Identifier validation request.
+     */
+    CENValidateIdentifierRequest: {
+      entity_type: components["schemas"]["IdentifierEntityType"];
+      /** Scheme Code */
+      scheme_code: string;
+      /** Value Raw */
+      value_raw: string;
+      granularity?: components["schemas"]["IdentifierGranularity"] | null;
+    };
+    /**
+     * CENValidateIdentifierResponse
+     * @description Identifier validation output with canonicalization.
+     */
+    CENValidateIdentifierResponse: {
+      /** Valid */
+      valid: boolean;
+      entity_type: components["schemas"]["IdentifierEntityType"];
+      /** Scheme Code */
+      scheme_code: string;
+      /** Value Raw */
+      value_raw: string;
+      /** Value Canonical */
+      value_canonical?: string | null;
+      granularity?: components["schemas"]["IdentifierGranularity"] | null;
+      /** Errors */
+      errors?: string[];
+      /** Warnings */
+      warnings?: string[];
     };
     /**
      * CaptureResponse
@@ -2035,6 +2692,31 @@ export interface components {
       /** Error Message */
       error_message?: string | null;
     };
+    /** CatalogSyncRequest */
+    CatalogSyncRequest: {
+      /**
+       * Include Deprecated
+       * @default true
+       */
+      include_deprecated?: boolean;
+    };
+    /** CatalogSyncResponse */
+    CatalogSyncResponse: {
+      /** Discovered */
+      discovered: number;
+      /** Ingested */
+      ingested: number;
+      /** Updated */
+      updated: number;
+      /** Skipped */
+      skipped: number;
+      /** Failed */
+      failed: number;
+      /** Source Repo Ref */
+      source_repo_ref: string;
+      /** Include Deprecated */
+      include_deprecated: boolean;
+    };
     /**
      * CategoryRuleset
      * @description All rules for a product category.
@@ -2093,6 +2775,464 @@ export interface components {
        * Format: uuid
        */
       tenant_id: string;
+    };
+    /**
+     * CirpassLabApiCallResponse
+     * @description API interaction metadata for under-the-hood inspector.
+     */
+    CirpassLabApiCallResponse: {
+      /**
+       * Method
+       * @enum {string}
+       */
+      method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+      /** Path */
+      path: string;
+      /**
+       * Auth
+       * @default none
+       * @enum {string}
+       */
+      auth?: "none" | "user" | "service";
+      /** Request Example */
+      request_example?: {
+        [key: string]: unknown;
+      } | null;
+      /** Expected Status */
+      expected_status?: number | null;
+      /** Response Example */
+      response_example?: {
+        [key: string]: unknown;
+      } | null;
+    };
+    /**
+     * CirpassLabArtifactsResponse
+     * @description Optional artifact snapshots displayed in diff inspector.
+     */
+    CirpassLabArtifactsResponse: {
+      /** Before */
+      before?: {
+        [key: string]: unknown;
+      } | null;
+      /** After */
+      after?: {
+        [key: string]: unknown;
+      } | null;
+      /** Diff Hint */
+      diff_hint?: string | null;
+    };
+    /**
+     * CirpassLabEventRequest
+     * @description Anonymized telemetry payload sent from the public lab client.
+     */
+    CirpassLabEventRequest: {
+      /** Session Token */
+      session_token: string;
+      /** Story Id */
+      story_id: string;
+      /** Step Id */
+      step_id: string;
+      /**
+       * Event Type
+       * @enum {string}
+       */
+      event_type: "step_view" | "step_submit" | "hint" | "mode_switch" | "reset_story" | "reset_all";
+      /**
+       * Mode
+       * @default mock
+       * @enum {string}
+       */
+      mode?: "mock" | "live";
+      /**
+       * Variant
+       * @default happy
+       * @enum {string}
+       */
+      variant?: "happy" | "unauthorized" | "not_found";
+      /**
+       * Result
+       * @default info
+       * @enum {string}
+       */
+      result?: "success" | "error" | "info";
+      /** Latency Ms */
+      latency_ms?: number | null;
+      /** Metadata */
+      metadata?: {
+        [key: string]: unknown;
+      };
+    };
+    /**
+     * CirpassLabEventResponse
+     * @description Telemetry ingestion acknowledgement.
+     */
+    CirpassLabEventResponse: {
+      /** Accepted */
+      accepted: boolean;
+      /** Event Id */
+      event_id: string;
+      /** Stored At */
+      stored_at: string;
+    };
+    /**
+     * CirpassLabFeatureFlagsResponse
+     * @description Feature-flag projection used by lab clients.
+     */
+    CirpassLabFeatureFlagsResponse: {
+      /** Scenario Engine Enabled */
+      scenario_engine_enabled: boolean;
+      /** Live Mode Enabled */
+      live_mode_enabled: boolean;
+      /** Inspector Enabled */
+      inspector_enabled: boolean;
+    };
+    /**
+     * CirpassLabInteractionFieldResponse
+     * @description Manifest-defined learner input field.
+     */
+    CirpassLabInteractionFieldResponse: {
+      /** Name */
+      name: string;
+      /** Label */
+      label: string;
+      /**
+       * Type
+       * @enum {string}
+       */
+      type: "text" | "textarea" | "number" | "checkbox" | "select";
+      /** Placeholder */
+      placeholder?: string | null;
+      /**
+       * Required
+       * @default false
+       */
+      required?: boolean;
+      /** Hint */
+      hint?: string | null;
+      validation?: components["schemas"]["CirpassLabInteractionValidationResponse"] | null;
+      /** Options */
+      options?: components["schemas"]["CirpassLabInteractionOptionResponse"][];
+      /** Test Id */
+      test_id?: string | null;
+    };
+    /**
+     * CirpassLabInteractionOptionResponse
+     * @description Choice entry used by select/scan interactions.
+     */
+    CirpassLabInteractionOptionResponse: {
+      /** Label */
+      label: string;
+      /** Value */
+      value: string;
+    };
+    /**
+     * CirpassLabInteractionValidationResponse
+     * @description Optional field-level validation hints for interaction rendering.
+     */
+    CirpassLabInteractionValidationResponse: {
+      /** Min Length */
+      min_length?: number | null;
+      /** Max Length */
+      max_length?: number | null;
+      /** Gt */
+      gt?: number | null;
+      /** Gte */
+      gte?: number | null;
+      /** Lt */
+      lt?: number | null;
+      /** Lte */
+      lte?: number | null;
+      /** Pattern */
+      pattern?: string | null;
+      /** Equals */
+      equals?: string | number | boolean | null;
+    };
+    /**
+     * CirpassLabManifestResponse
+     * @description Resolved CIRPASS lab manifest served by public API.
+     */
+    CirpassLabManifestResponse: {
+      /** Manifest Version */
+      manifest_version: string;
+      /** Story Version */
+      story_version: string;
+      /** Generated At */
+      generated_at: string;
+      /**
+       * Source Status
+       * @enum {string}
+       */
+      source_status: "fresh" | "fallback";
+      /** Stories */
+      stories: components["schemas"]["CirpassLabStoryResponse"][];
+      feature_flags: components["schemas"]["CirpassLabFeatureFlagsResponse"];
+    };
+    /**
+     * CirpassLabPolicyInspectorResponse
+     * @description Optional policy/authorization hints for a step.
+     */
+    CirpassLabPolicyInspectorResponse: {
+      /** Required Role */
+      required_role?: string | null;
+      /** Opa Policy */
+      opa_policy?: string | null;
+      /** Expected Decision */
+      expected_decision?: ("allow" | "deny" | "mask") | null;
+      /** Note */
+      note?: string | null;
+    };
+    /**
+     * CirpassLabReferenceResponse
+     * @description Citation metadata for scenario narratives.
+     */
+    CirpassLabReferenceResponse: {
+      /** Label */
+      label: string;
+      /** Ref */
+      ref: string;
+    };
+    /**
+     * CirpassLabStepCheckResponse
+     * @description Validation check metadata attached to a step.
+     */
+    CirpassLabStepCheckResponse: {
+      /**
+       * Type
+       * @enum {string}
+       */
+      type: "jsonpath" | "jmespath" | "status" | "schema";
+      /** Expression */
+      expression?: string | null;
+      /** Expected */
+      expected?: string | number | boolean | {
+        [key: string]: unknown;
+      } | unknown[] | null;
+    };
+    /**
+     * CirpassLabStepInteractionResponse
+     * @description Manifest-defined interaction descriptor consumed by the runner.
+     */
+    CirpassLabStepInteractionResponse: {
+      /**
+       * Kind
+       * @default form
+       * @enum {string}
+       */
+      kind?: "click" | "form" | "scan" | "select";
+      /**
+       * Submit Label
+       * @default Validate & Continue
+       */
+      submit_label?: string;
+      /** Hint Text */
+      hint_text?: string | null;
+      /** Success Message */
+      success_message?: string | null;
+      /** Failure Message */
+      failure_message?: string | null;
+      /** Fields */
+      fields?: components["schemas"]["CirpassLabInteractionFieldResponse"][];
+      /** Options */
+      options?: components["schemas"]["CirpassLabInteractionOptionResponse"][];
+    };
+    /**
+     * CirpassLabStepResponse
+     * @description Data-driven CIRPASS story step consumed by the scenario runner.
+     */
+    CirpassLabStepResponse: {
+      /** Id */
+      id: string;
+      /**
+       * Level
+       * @enum {string}
+       */
+      level: "create" | "access" | "update" | "transfer" | "deactivate";
+      /** Title */
+      title: string;
+      /** Actor */
+      actor: string;
+      /** Intent */
+      intent: string;
+      /** Explanation Md */
+      explanation_md: string;
+      ui_action?: components["schemas"]["CirpassLabUiActionResponse"] | null;
+      interaction?: components["schemas"]["CirpassLabStepInteractionResponse"] | null;
+      /** Actor Goal */
+      actor_goal?: string | null;
+      /** Physical Story Md */
+      physical_story_md?: string | null;
+      /** Why It Matters Md */
+      why_it_matters_md?: string | null;
+      api?: components["schemas"]["CirpassLabApiCallResponse"] | null;
+      artifacts?: components["schemas"]["CirpassLabArtifactsResponse"] | null;
+      /** Checks */
+      checks?: components["schemas"]["CirpassLabStepCheckResponse"][];
+      policy?: components["schemas"]["CirpassLabPolicyInspectorResponse"] | null;
+      /** Variants */
+      variants?: ("happy" | "unauthorized" | "not_found")[];
+    };
+    /**
+     * CirpassLabStoryResponse
+     * @description Scenario story bundle containing ordered executable steps.
+     */
+    CirpassLabStoryResponse: {
+      /** Id */
+      id: string;
+      /** Title */
+      title: string;
+      /** Summary */
+      summary: string;
+      /** Personas */
+      personas: string[];
+      /** Learning Goals */
+      learning_goals?: string[];
+      /** Preconditions Md */
+      preconditions_md?: string | null;
+      /** References */
+      references?: components["schemas"]["CirpassLabReferenceResponse"][];
+      /** Version */
+      version?: string | null;
+      /** Last Reviewed */
+      last_reviewed?: string | null;
+      /** Steps */
+      steps: components["schemas"]["CirpassLabStepResponse"][];
+    };
+    /**
+     * CirpassLabUiActionResponse
+     * @description Learner-facing UI action descriptor.
+     */
+    CirpassLabUiActionResponse: {
+      /** Label */
+      label: string;
+      /**
+       * Kind
+       * @enum {string}
+       */
+      kind: "click" | "form" | "scan" | "select";
+    };
+    /**
+     * CirpassLeaderboardEntryResponse
+     * @description Public leaderboard row.
+     */
+    CirpassLeaderboardEntryResponse: {
+      /** Rank */
+      rank: number;
+      /** Nickname */
+      nickname: string;
+      /** Score */
+      score: number;
+      /** Completion Seconds */
+      completion_seconds: number;
+      /** Version */
+      version: string;
+      /** Created At */
+      created_at: string;
+    };
+    /**
+     * CirpassLeaderboardResponse
+     * @description Leaderboard listing for a specific or latest version.
+     */
+    CirpassLeaderboardResponse: {
+      /** Version */
+      version: string;
+      /** Entries */
+      entries: components["schemas"]["CirpassLeaderboardEntryResponse"][];
+    };
+    /**
+     * CirpassLeaderboardSubmitRequest
+     * @description Payload for public score submissions.
+     */
+    CirpassLeaderboardSubmitRequest: {
+      /** Session Token */
+      session_token: string;
+      /** Nickname */
+      nickname: string;
+      /** Score */
+      score: number;
+      /** Completion Seconds */
+      completion_seconds: number;
+      /** Version */
+      version: string;
+    };
+    /**
+     * CirpassLeaderboardSubmitResponse
+     * @description Submission result and current leaderboard rank snapshot.
+     */
+    CirpassLeaderboardSubmitResponse: {
+      /** Accepted */
+      accepted: boolean;
+      /** Rank */
+      rank?: number | null;
+      /** Best Score */
+      best_score?: number | null;
+      /** Version */
+      version: string;
+    };
+    /**
+     * CirpassLevelResponse
+     * @description Stories mapped to one simulator lifecycle level.
+     */
+    CirpassLevelResponse: {
+      /**
+       * Level
+       * @enum {string}
+       */
+      level: "create" | "access" | "update" | "transfer" | "deactivate";
+      /** Label */
+      label: string;
+      /** Objective */
+      objective: string;
+      /** Stories */
+      stories: components["schemas"]["CirpassStoryResponse"][];
+    };
+    /**
+     * CirpassSessionResponse
+     * @description Public anonymous session token used for leaderboard submissions.
+     */
+    CirpassSessionResponse: {
+      /** Session Token */
+      session_token: string;
+      /** Expires At */
+      expires_at: string;
+    };
+    /**
+     * CirpassStoryFeedResponse
+     * @description Latest normalized CIRPASS story feed for simulator consumption.
+     */
+    CirpassStoryFeedResponse: {
+      /** Version */
+      version: string;
+      /** Release Date */
+      release_date?: string | null;
+      /** Source Url */
+      source_url: string;
+      /** Zenodo Record Url */
+      zenodo_record_url: string;
+      /**
+       * Source Status
+       * @enum {string}
+       */
+      source_status: "fresh" | "stale";
+      /** Generated At */
+      generated_at: string;
+      /** Fetched At */
+      fetched_at: string;
+      /** Levels */
+      levels: components["schemas"]["CirpassLevelResponse"][];
+    };
+    /**
+     * CirpassStoryResponse
+     * @description Single user story summary extracted from source documents.
+     */
+    CirpassStoryResponse: {
+      /** Id */
+      id: string;
+      /** Title */
+      title: string;
+      /** Summary */
+      summary: string;
+      /** Technical Note */
+      technical_note?: string | null;
     };
     /**
      * ComparisonReport
@@ -2305,7 +3445,7 @@ export interface components {
       status: string;
       /** Created By Subject */
       created_by_subject: string;
-      created_by: components["schemas"]["app__modules__connectors__router__ActorSummary"];
+      created_by: components["schemas"]["ActorSummary"];
       /** Visibility Scope */
       visibility_scope: string;
       access: components["schemas"]["AccessSummary"];
@@ -2396,6 +3536,12 @@ export interface components {
       /** Expiration Date */
       expiration_date?: string | null;
     };
+    /**
+     * DPPBindingMode
+     * @description How an OPC UA mapping resolves to a target DPP.
+     * @enum {string}
+     */
+    DPPBindingMode: "by_dpp_id" | "by_asset_ids" | "by_serial_scan";
     /**
      * DPPDetailResponse
      * @description Detailed response model including revision data.
@@ -2671,6 +3817,11 @@ export interface components {
        * @default 4
        */
       quiet_zone_modules?: number;
+      /**
+       * Nfc Memory Bytes
+       * @default 512
+       */
+      nfc_memory_bytes?: number;
     };
     /**
      * DataCarrierListResponse
@@ -2698,6 +3849,16 @@ export interface components {
       instructions?: string | null;
       /** Human Readable Fallback */
       human_readable_fallback?: string | null;
+      /** Print Method */
+      print_method?: string | null;
+      /** Substrate */
+      substrate?: string | null;
+      /** Expected Lifetime Months */
+      expected_lifetime_months?: number | null;
+      /** Environment */
+      environment?: string | null;
+      /** Qa Grade */
+      qa_grade?: string | null;
     };
     /**
      * DataCarrierPreSalePackResponse
@@ -2720,6 +3881,85 @@ export interface components {
       encoded_uri: string;
       /** Widget Html */
       widget_html: string;
+    };
+    /**
+     * DataCarrierQACheckResult
+     * @description Single QA check result.
+     */
+    DataCarrierQACheckResult: {
+      /** Check Type */
+      check_type: string;
+      /** Passed */
+      passed: boolean;
+      /**
+       * Severity
+       * @default info
+       */
+      severity?: string;
+      /** Message */
+      message: string;
+      /** Details */
+      details?: {
+        [key: string]: unknown;
+      };
+    };
+    /**
+     * DataCarrierQAResponse
+     * @description Computed QA report for a carrier.
+     */
+    DataCarrierQAResponse: {
+      /**
+       * Carrier Id
+       * Format: uuid
+       */
+      carrier_id: string;
+      /** Checks */
+      checks: components["schemas"]["DataCarrierQACheckResult"][];
+    };
+    /**
+     * DataCarrierQualityCheckCreateRequest
+     * @description Persisted quality-check input.
+     */
+    DataCarrierQualityCheckCreateRequest: {
+      /** Check Type */
+      check_type: string;
+      /** Passed */
+      passed: boolean;
+      /** Results */
+      results?: {
+        [key: string]: unknown;
+      };
+    };
+    /**
+     * DataCarrierQualityCheckResponse
+     * @description Persisted quality-check response.
+     */
+    DataCarrierQualityCheckResponse: {
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /**
+       * Carrier Id
+       * Format: uuid
+       */
+      carrier_id: string;
+      /** Check Type */
+      check_type: string;
+      /** Passed */
+      passed: boolean;
+      /** Results */
+      results: {
+        [key: string]: unknown;
+      };
+      /** Performed By Subject */
+      performed_by_subject: string;
+      /**
+       * Performed At
+       * Format: date-time
+       */
+      performed_at: string;
     };
     /**
      * DataCarrierRegistryExportItem
@@ -2820,8 +4060,12 @@ export interface components {
       identifier_data: {
         [key: string]: string;
       };
+      /** External Identifier Id */
+      external_identifier_id: string | null;
       /** Encoded Uri */
       encoded_uri: string;
+      /** Payload Sha256 */
+      payload_sha256: string | null;
       /** Layout Profile */
       layout_profile: {
         [key: string]: unknown;
@@ -2874,6 +4118,33 @@ export interface components {
       placement_metadata?: components["schemas"]["DataCarrierPlacementMetadata"] | null;
       /** Pre Sale Enabled */
       pre_sale_enabled?: boolean | null;
+    };
+    /**
+     * DataCarrierValidationRequest
+     * @description Pre-flight payload validation request.
+     */
+    DataCarrierValidationRequest: {
+      carrier_type: components["schemas"]["DataCarrierType"];
+      /** Payload */
+      payload: string;
+      layout_profile?: components["schemas"]["DataCarrierLayoutProfile"];
+    };
+    /**
+     * DataCarrierValidationResponse
+     * @description Pre-flight payload validation response.
+     */
+    DataCarrierValidationResponse: {
+      /** Valid */
+      valid: boolean;
+      carrier_type: components["schemas"]["DataCarrierType"];
+      /** Payload Bytes */
+      payload_bytes: number;
+      /** Warnings */
+      warnings?: string[];
+      /** Details */
+      details?: {
+        [key: string]: unknown;
+      };
     };
     /**
      * DataCarrierWithdrawRequest
@@ -2978,6 +4249,74 @@ export interface components {
       /** Secrets */
       secrets?: components["schemas"]["SecretValueWrite"][] | null;
     };
+    /**
+     * DataspacePublicationJobListResponse
+     * @description Paginated list of publication jobs.
+     */
+    DataspacePublicationJobListResponse: {
+      /** Items */
+      items: components["schemas"]["DataspacePublicationJobResponse"][];
+      /** Total */
+      total: number;
+    };
+    /**
+     * DataspacePublicationJobResponse
+     * @description Dataspace publication job summary.
+     */
+    DataspacePublicationJobResponse: {
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /**
+       * Tenant Id
+       * Format: uuid
+       */
+      tenant_id: string;
+      /**
+       * Dpp Id
+       * Format: uuid
+       */
+      dpp_id: string;
+      /** Status */
+      status: string;
+      /** Target */
+      target: string;
+      /** Artifact Refs */
+      artifact_refs?: {
+        [key: string]: unknown;
+      };
+      /** Error */
+      error?: string | null;
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string;
+      /**
+       * Updated At
+       * Format: date-time
+       */
+      updated_at: string;
+    };
+    /**
+     * DataspacePublishRequest
+     * @description Request to publish a DPP to a dataspace (DTR + EDC).
+     */
+    DataspacePublishRequest: {
+      /**
+       * Dppid
+       * Format: uuid
+       */
+      dppId: string;
+      /**
+       * Target
+       * @description Target ecosystem
+       * @default catena-x
+       */
+      target?: string;
+    };
     /** DeliveryLogResponse */
     DeliveryLogResponse: {
       /**
@@ -3028,6 +4367,30 @@ export interface components {
       old_value?: unknown;
       /** New Value */
       new_value?: unknown;
+    };
+    /**
+     * DryRunDiffEntry
+     * @description Single diff entry from a dry-run patch preview.
+     */
+    DryRunDiffEntry: {
+      /** Op */
+      op: string;
+      /** Path */
+      path: string;
+      /** Oldvalue */
+      oldValue?: unknown;
+      /** Newvalue */
+      newValue?: unknown;
+    };
+    /**
+     * DryRunRequest
+     * @description Optional input for dry-run: override the DPP revision JSON.
+     */
+    DryRunRequest: {
+      /** Revisionjson */
+      revisionJson?: {
+        [key: string]: unknown;
+      } | null;
     };
     /**
      * EDCHealthResponse
@@ -3261,6 +4624,51 @@ export interface components {
       /** Eventlist */
       eventList: components["schemas"]["EPCISEventResponse"][];
     };
+    /** EconomicOperatorCreateRequest */
+    EconomicOperatorCreateRequest: {
+      /** Legal Name */
+      legal_name: string;
+      /** Country */
+      country?: string | null;
+      /** Metadata Json */
+      metadata_json?: {
+        [key: string]: unknown;
+      };
+      identifier?: components["schemas"]["IdentifierRegisterRequest"] | null;
+    };
+    /** EconomicOperatorResponse */
+    EconomicOperatorResponse: {
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /**
+       * Tenant Id
+       * Format: uuid
+       */
+      tenant_id: string;
+      /** Legal Name */
+      legal_name: string;
+      /** Country */
+      country?: string | null;
+      /** Metadata Json */
+      metadata_json: {
+        [key: string]: unknown;
+      };
+      /** Created By Subject */
+      created_by_subject: string;
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string;
+      /**
+       * Updated At
+       * Format: date-time
+       */
+      updated_at: string;
+    };
     /**
      * ErrorDeclaration
      * @description EPCIS error declaration for correcting a previous event.
@@ -3291,6 +4699,47 @@ export interface components {
       /** Event Hash */
       event_hash?: string | null;
     };
+    /** ExternalIdentifierResponse */
+    ExternalIdentifierResponse: {
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /**
+       * Tenant Id
+       * Format: uuid
+       */
+      tenant_id: string;
+      entity_type: components["schemas"]["IdentifierEntityType"];
+      /** Scheme Code */
+      scheme_code: string;
+      /** Value Raw */
+      value_raw: string;
+      /** Value Canonical */
+      value_canonical: string;
+      granularity?: components["schemas"]["IdentifierGranularity"] | null;
+      /** Status */
+      status: string;
+      /** Replaced By Identifier Id */
+      replaced_by_identifier_id?: string | null;
+      /** Issued At */
+      issued_at?: string | null;
+      /** Deprecates At */
+      deprecates_at?: string | null;
+      /** Created By Subject */
+      created_by_subject: string;
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string;
+      /**
+       * Updated At
+       * Format: date-time
+       */
+      updated_at: string;
+    };
     /**
      * ExternalPCFApiRef
      * @description External PCF API reference discovered in Carbon Footprint submodels.
@@ -3304,6 +4753,65 @@ export interface components {
       source_submodel?: string | null;
       /** Source Path */
       source_path?: string | null;
+    };
+    /** FacilityCreateRequest */
+    FacilityCreateRequest: {
+      /**
+       * Operator Id
+       * Format: uuid
+       */
+      operator_id: string;
+      /** Facility Name */
+      facility_name: string;
+      /** Address */
+      address?: {
+        [key: string]: unknown;
+      };
+      /** Metadata Json */
+      metadata_json?: {
+        [key: string]: unknown;
+      };
+      identifier?: components["schemas"]["IdentifierRegisterRequest"] | null;
+    };
+    /** FacilityResponse */
+    FacilityResponse: {
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /**
+       * Tenant Id
+       * Format: uuid
+       */
+      tenant_id: string;
+      /**
+       * Operator Id
+       * Format: uuid
+       */
+      operator_id: string;
+      /** Facility Name */
+      facility_name: string;
+      /** Address */
+      address: {
+        [key: string]: unknown;
+      };
+      /** Metadata Json */
+      metadata_json: {
+        [key: string]: unknown;
+      };
+      /** Created By Subject */
+      created_by_subject: string;
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string;
+      /**
+       * Updated At
+       * Format: date-time
+       */
+      updated_at: string;
     };
     /**
      * GS1DigitalLinkResponse
@@ -3390,6 +4898,65 @@ export interface components {
        * @default
        */
       serial_number?: string;
+    };
+    /**
+     * IdentifierEntityType
+     * @enum {string}
+     */
+    IdentifierEntityType: "product" | "operator" | "facility";
+    /**
+     * IdentifierGranularity
+     * @enum {string}
+     */
+    IdentifierGranularity: "model" | "batch" | "item";
+    /** IdentifierRegisterRequest */
+    IdentifierRegisterRequest: {
+      entity_type: components["schemas"]["IdentifierEntityType"];
+      /** Scheme Code */
+      scheme_code: string;
+      /** Value Raw */
+      value_raw: string;
+      granularity?: components["schemas"]["IdentifierGranularity"] | null;
+      /** Dpp Id */
+      dpp_id?: string | null;
+      /** Operator Id */
+      operator_id?: string | null;
+      /** Facility Id */
+      facility_id?: string | null;
+    };
+    /** IdentifierSupersedeRequest */
+    IdentifierSupersedeRequest: {
+      /**
+       * Replacement Identifier Id
+       * Format: uuid
+       */
+      replacement_identifier_id: string;
+    };
+    /** IdentifierValidateRequest */
+    IdentifierValidateRequest: {
+      entity_type: components["schemas"]["IdentifierEntityType"];
+      /** Scheme Code */
+      scheme_code: string;
+      /** Value Raw */
+      value_raw: string;
+      granularity?: components["schemas"]["IdentifierGranularity"] | null;
+    };
+    /** IdentifierValidateResponse */
+    IdentifierValidateResponse: {
+      /** Valid */
+      valid: boolean;
+      entity_type: components["schemas"]["IdentifierEntityType"];
+      /** Scheme Code */
+      scheme_code: string;
+      /** Value Raw */
+      value_raw: string;
+      /** Value Canonical */
+      value_canonical?: string | null;
+      granularity?: components["schemas"]["IdentifierGranularity"] | null;
+      /** Errors */
+      errors?: string[];
+      /** Warnings */
+      warnings?: string[];
     };
     /**
      * ImportDPPRequest
@@ -3479,6 +5046,47 @@ export interface components {
       /** Methodology Disclosure */
       methodology_disclosure?: string | null;
     };
+    /** LabResetResponse */
+    LabResetResponse: {
+      /** Tenant */
+      tenant: string;
+      /** Scenario */
+      scenario: string;
+      /** Dataset Hash */
+      dataset_hash: string;
+      /** Reset Count */
+      reset_count: number;
+      /** Status */
+      status: string;
+    };
+    /** LabSeedResponse */
+    LabSeedResponse: {
+      /** Tenant */
+      tenant: string;
+      /** Scenario */
+      scenario: string;
+      /** Dataset Hash */
+      dataset_hash: string;
+      /** Seeded At */
+      seeded_at: string;
+      /** Status */
+      status: string;
+    };
+    /** LabStatusResponse */
+    LabStatusResponse: {
+      /** Tenant */
+      tenant: string;
+      /** Scenario */
+      scenario: string;
+      /** Dataset Hash */
+      dataset_hash: string;
+      /** Reset Count */
+      reset_count: number;
+      /** Status */
+      status: string;
+      /** Live Mode Enabled */
+      live_mode_enabled: boolean;
+    };
     /**
      * LifecyclePhase
      * @description Product lifecycle phase for digital thread events.
@@ -3554,6 +5162,37 @@ export interface components {
       has_changes: boolean;
       /** Changes */
       changes: components["schemas"]["ManifestChange"][];
+    };
+    /**
+     * MappingDryRunResult
+     * @description Result of a mapping dry-run against a DPP revision.
+     */
+    MappingDryRunResult: {
+      /**
+       * Mappingid
+       * Format: uuid
+       */
+      mappingId: string;
+      /** Dppid */
+      dppId?: string | null;
+      /** Diff */
+      diff?: components["schemas"]["DryRunDiffEntry"][];
+      /** Appliedvalue */
+      appliedValue?: unknown;
+      /** Transformoutput */
+      transformOutput?: unknown;
+    };
+    /**
+     * MappingValidationResult
+     * @description Result of validating a mapping's configuration.
+     */
+    MappingValidationResult: {
+      /** Isvalid */
+      isValid: boolean;
+      /** Errors */
+      errors?: string[];
+      /** Warnings */
+      warnings?: string[];
     };
     /**
      * MasterAliasesUpdateRequest
@@ -3965,6 +5604,516 @@ export interface components {
       updated_at: string;
     };
     /**
+     * NodeSearchResult
+     * @description Single node from a parsed node graph search.
+     */
+    NodeSearchResult: {
+      /** Nodeid */
+      nodeId: string;
+      /** Browsename */
+      browseName: string;
+      /** Nodeclass */
+      nodeClass: string;
+      /** Datatype */
+      dataType?: string | null;
+      /** Description */
+      description?: string | null;
+      /** Engineeringunit */
+      engineeringUnit?: string | null;
+      /** Parentnodeid */
+      parentNodeId?: string | null;
+    };
+    /**
+     * OPCUAAuthType
+     * @description Authentication method for OPC UA source connections.
+     * @enum {string}
+     */
+    OPCUAAuthType: "anonymous" | "username_password" | "certificate";
+    /**
+     * OPCUAConnectionStatus
+     * @description Health status of an OPC UA source connection.
+     * @enum {string}
+     */
+    OPCUAConnectionStatus: "disabled" | "healthy" | "degraded" | "error";
+    /**
+     * OPCUAFeatureStatusResponse
+     * @description Runtime feature status for OPC UA integration.
+     */
+    OPCUAFeatureStatusResponse: {
+      /** Enabled */
+      enabled: boolean;
+    };
+    /**
+     * OPCUAMappingCreate
+     * @description Create a new OPC UA → AAS/EPCIS mapping.
+     */
+    OPCUAMappingCreate: {
+      /**
+       * Sourceid
+       * Format: uuid
+       */
+      sourceId: string;
+      /** Nodesetid */
+      nodesetId?: string | null;
+      mappingType: components["schemas"]["OPCUAMappingType"];
+      /** Opcuanodeid */
+      opcuaNodeId: string;
+      /** Opcuabrowsepath */
+      opcuaBrowsePath?: string | null;
+      /** Opcuadatatype */
+      opcuaDatatype?: string | null;
+      /** Samplingintervalms */
+      samplingIntervalMs?: number | null;
+      /** @default by_dpp_id */
+      dppBindingMode?: components["schemas"]["DPPBindingMode"];
+      /** Dppid */
+      dppId?: string | null;
+      /** Assetidquery */
+      assetIdQuery?: {
+        [key: string]: unknown;
+      } | null;
+      /** Targettemplatekey */
+      targetTemplateKey?: string | null;
+      /** Targetsubmodelid */
+      targetSubmodelId?: string | null;
+      /** Targetaaspath */
+      targetAasPath?: string | null;
+      /** Patchop */
+      patchOp?: string | null;
+      /** Valuetransformexpr */
+      valueTransformExpr?: string | null;
+      /** Unithint */
+      unitHint?: string | null;
+      /** Sammaspecturn */
+      sammAspectUrn?: string | null;
+      /** Sammproperty */
+      sammProperty?: string | null;
+      /** Sammversion */
+      sammVersion?: string | null;
+      /** Epciseventtype */
+      epcisEventType?: string | null;
+      /** Epcisbizstep */
+      epcisBizStep?: string | null;
+      /** Epcisdisposition */
+      epcisDisposition?: string | null;
+      /** Epcisaction */
+      epcisAction?: string | null;
+      /** Epcisreadpoint */
+      epcisReadPoint?: string | null;
+      /** Epcisbizlocation */
+      epcisBizLocation?: string | null;
+      /** Epcissourceeventidtemplate */
+      epcisSourceEventIdTemplate?: string | null;
+      /**
+       * Isenabled
+       * @default true
+       */
+      isEnabled?: boolean;
+    };
+    /**
+     * OPCUAMappingListResponse
+     * @description Paginated list of OPC UA mappings.
+     */
+    OPCUAMappingListResponse: {
+      /** Items */
+      items: components["schemas"]["OPCUAMappingResponse"][];
+      /** Total */
+      total: number;
+    };
+    /**
+     * OPCUAMappingResponse
+     * @description OPC UA mapping detail.
+     */
+    OPCUAMappingResponse: {
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /**
+       * Tenant Id
+       * Format: uuid
+       */
+      tenant_id: string;
+      /**
+       * Source Id
+       * Format: uuid
+       */
+      source_id: string;
+      /** Nodeset Id */
+      nodeset_id?: string | null;
+      mapping_type: components["schemas"]["OPCUAMappingType"];
+      /** Opcua Node Id */
+      opcua_node_id: string;
+      /** Opcua Browse Path */
+      opcua_browse_path?: string | null;
+      /** Opcua Datatype */
+      opcua_datatype?: string | null;
+      /** Sampling Interval Ms */
+      sampling_interval_ms?: number | null;
+      dpp_binding_mode: components["schemas"]["DPPBindingMode"];
+      /** Dpp Id */
+      dpp_id?: string | null;
+      /** Asset Id Query */
+      asset_id_query?: {
+        [key: string]: unknown;
+      } | null;
+      /** Target Template Key */
+      target_template_key?: string | null;
+      /** Target Submodel Id */
+      target_submodel_id?: string | null;
+      /** Target Aas Path */
+      target_aas_path?: string | null;
+      /** Patch Op */
+      patch_op?: string | null;
+      /** Value Transform Expr */
+      value_transform_expr?: string | null;
+      /** Unit Hint */
+      unit_hint?: string | null;
+      /** Samm Aspect Urn */
+      samm_aspect_urn?: string | null;
+      /** Samm Property */
+      samm_property?: string | null;
+      /** Samm Version */
+      samm_version?: string | null;
+      /** Epcis Event Type */
+      epcis_event_type?: string | null;
+      /** Epcis Biz Step */
+      epcis_biz_step?: string | null;
+      /** Epcis Disposition */
+      epcis_disposition?: string | null;
+      /** Epcis Action */
+      epcis_action?: string | null;
+      /** Epcis Read Point */
+      epcis_read_point?: string | null;
+      /** Epcis Biz Location */
+      epcis_biz_location?: string | null;
+      /** Epcis Source Event Id Template */
+      epcis_source_event_id_template?: string | null;
+      /** Is Enabled */
+      is_enabled: boolean;
+      /** Created By */
+      created_by: string;
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string;
+      /**
+       * Updated At
+       * Format: date-time
+       */
+      updated_at: string;
+    };
+    /**
+     * OPCUAMappingType
+     * @description Discriminator for how an OPC UA mapping is applied.
+     * @enum {string}
+     */
+    OPCUAMappingType: "aas_patch" | "epcis_event";
+    /**
+     * OPCUAMappingUpdate
+     * @description Partial update for an OPC UA mapping.
+     */
+    OPCUAMappingUpdate: {
+      /** Nodesetid */
+      nodesetId?: string | null;
+      mappingType?: components["schemas"]["OPCUAMappingType"] | null;
+      /** Opcuanodeid */
+      opcuaNodeId?: string | null;
+      /** Opcuabrowsepath */
+      opcuaBrowsePath?: string | null;
+      /** Opcuadatatype */
+      opcuaDatatype?: string | null;
+      /** Samplingintervalms */
+      samplingIntervalMs?: number | null;
+      dppBindingMode?: components["schemas"]["DPPBindingMode"] | null;
+      /** Dppid */
+      dppId?: string | null;
+      /** Assetidquery */
+      assetIdQuery?: {
+        [key: string]: unknown;
+      } | null;
+      /** Targettemplatekey */
+      targetTemplateKey?: string | null;
+      /** Targetsubmodelid */
+      targetSubmodelId?: string | null;
+      /** Targetaaspath */
+      targetAasPath?: string | null;
+      /** Patchop */
+      patchOp?: string | null;
+      /** Valuetransformexpr */
+      valueTransformExpr?: string | null;
+      /** Unithint */
+      unitHint?: string | null;
+      /** Sammaspecturn */
+      sammAspectUrn?: string | null;
+      /** Sammproperty */
+      sammProperty?: string | null;
+      /** Sammversion */
+      sammVersion?: string | null;
+      /** Epciseventtype */
+      epcisEventType?: string | null;
+      /** Epcisbizstep */
+      epcisBizStep?: string | null;
+      /** Epcisdisposition */
+      epcisDisposition?: string | null;
+      /** Epcisaction */
+      epcisAction?: string | null;
+      /** Epcisreadpoint */
+      epcisReadPoint?: string | null;
+      /** Epcisbizlocation */
+      epcisBizLocation?: string | null;
+      /** Epcissourceeventidtemplate */
+      epcisSourceEventIdTemplate?: string | null;
+      /** Isenabled */
+      isEnabled?: boolean | null;
+    };
+    /**
+     * OPCUANodeSetDetailResponse
+     * @description NodeSet with full parsed node graph (for detail endpoint).
+     */
+    OPCUANodeSetDetailResponse: {
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /**
+       * Tenant Id
+       * Format: uuid
+       */
+      tenant_id: string;
+      /** Source Id */
+      source_id?: string | null;
+      /** Namespace Uri */
+      namespace_uri: string;
+      /** Nodeset Version */
+      nodeset_version?: string | null;
+      /** Publication Date */
+      publication_date?: string | null;
+      /** Companion Spec Name */
+      companion_spec_name?: string | null;
+      /** Companion Spec Version */
+      companion_spec_version?: string | null;
+      /** Nodeset File Ref */
+      nodeset_file_ref: string;
+      /** Companion Spec File Ref */
+      companion_spec_file_ref?: string | null;
+      /** Hash Sha256 */
+      hash_sha256: string;
+      /** Parsed Summary Json */
+      parsed_summary_json: {
+        [key: string]: unknown;
+      };
+      /**
+       * Node Count
+       * @default 0
+       */
+      node_count?: number;
+      /** Created By */
+      created_by: string;
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string;
+      /**
+       * Updated At
+       * Format: date-time
+       */
+      updated_at: string;
+      /** Parsed Node Graph */
+      parsed_node_graph?: {
+        [key: string]: unknown;
+      };
+    };
+    /**
+     * OPCUANodeSetListResponse
+     * @description Paginated list of OPC UA nodesets.
+     */
+    OPCUANodeSetListResponse: {
+      /** Items */
+      items: components["schemas"]["OPCUANodeSetResponse"][];
+      /** Total */
+      total: number;
+    };
+    /**
+     * OPCUANodeSetResponse
+     * @description OPC UA NodeSet summary.
+     */
+    OPCUANodeSetResponse: {
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /**
+       * Tenant Id
+       * Format: uuid
+       */
+      tenant_id: string;
+      /** Source Id */
+      source_id?: string | null;
+      /** Namespace Uri */
+      namespace_uri: string;
+      /** Nodeset Version */
+      nodeset_version?: string | null;
+      /** Publication Date */
+      publication_date?: string | null;
+      /** Companion Spec Name */
+      companion_spec_name?: string | null;
+      /** Companion Spec Version */
+      companion_spec_version?: string | null;
+      /** Nodeset File Ref */
+      nodeset_file_ref: string;
+      /** Companion Spec File Ref */
+      companion_spec_file_ref?: string | null;
+      /** Hash Sha256 */
+      hash_sha256: string;
+      /** Parsed Summary Json */
+      parsed_summary_json: {
+        [key: string]: unknown;
+      };
+      /**
+       * Node Count
+       * @default 0
+       */
+      node_count?: number;
+      /** Created By */
+      created_by: string;
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string;
+      /**
+       * Updated At
+       * Format: date-time
+       */
+      updated_at: string;
+    };
+    /**
+     * OPCUASourceCreate
+     * @description Create a new OPC UA source.
+     */
+    OPCUASourceCreate: {
+      /** Name */
+      name: string;
+      /**
+       * Endpointurl
+       * @description OPC UA endpoint URL, e.g. opc.tcp://host:4840
+       */
+      endpointUrl: string;
+      /** Securitypolicy */
+      securityPolicy?: string | null;
+      /** Securitymode */
+      securityMode?: string | null;
+      /** @default anonymous */
+      authType?: components["schemas"]["OPCUAAuthType"];
+      /** Username */
+      username?: string | null;
+      /**
+       * Password
+       * @description Plaintext password — encrypted before storage
+       */
+      password?: string | null;
+      /** Clientcertref */
+      clientCertRef?: string | null;
+      /** Clientkeyref */
+      clientKeyRef?: string | null;
+      /** Servercertpinnedsha256 */
+      serverCertPinnedSha256?: string | null;
+    };
+    /**
+     * OPCUASourceListResponse
+     * @description Paginated list of OPC UA sources.
+     */
+    OPCUASourceListResponse: {
+      /** Items */
+      items: components["schemas"]["OPCUASourceResponse"][];
+      /** Total */
+      total: number;
+    };
+    /**
+     * OPCUASourceResponse
+     * @description OPC UA source detail — password is NEVER exposed.
+     */
+    OPCUASourceResponse: {
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /**
+       * Tenant Id
+       * Format: uuid
+       */
+      tenant_id: string;
+      /** Name */
+      name: string;
+      /** Endpoint Url */
+      endpoint_url: string;
+      /** Security Policy */
+      security_policy?: string | null;
+      /** Security Mode */
+      security_mode?: string | null;
+      auth_type: components["schemas"]["OPCUAAuthType"];
+      /** Username */
+      username?: string | null;
+      /**
+       * Has Password
+       * @default false
+       */
+      has_password?: boolean;
+      /** Client Cert Ref */
+      client_cert_ref?: string | null;
+      /** Client Key Ref */
+      client_key_ref?: string | null;
+      /** Server Cert Pinned Sha256 */
+      server_cert_pinned_sha256?: string | null;
+      connection_status: components["schemas"]["OPCUAConnectionStatus"];
+      /** Last Seen At */
+      last_seen_at?: string | null;
+      /** Created By */
+      created_by: string;
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string;
+      /**
+       * Updated At
+       * Format: date-time
+       */
+      updated_at: string;
+    };
+    /**
+     * OPCUASourceUpdate
+     * @description Partial update for an OPC UA source.
+     */
+    OPCUASourceUpdate: {
+      /** Name */
+      name?: string | null;
+      /** Endpointurl */
+      endpointUrl?: string | null;
+      /** Securitypolicy */
+      securityPolicy?: string | null;
+      /** Securitymode */
+      securityMode?: string | null;
+      authType?: components["schemas"]["OPCUAAuthType"] | null;
+      /** Username */
+      username?: string | null;
+      /** Password */
+      password?: string | null;
+      /** Clientcertref */
+      clientCertRef?: string | null;
+      /** Clientkeyref */
+      clientKeyRef?: string | null;
+      /** Servercertpinnedsha256 */
+      serverCertPinnedSha256?: string | null;
+    };
+    /**
      * ObjectEventCreate
      * @description EPCIS ObjectEvent — most common type, tracks observations of objects.
      */
@@ -4258,6 +6407,37 @@ export interface components {
      */
     PolicyType: "route" | "submodel" | "element";
     /**
+     * PublicDPPIntegrityResponse
+     * @description Integrity bundle for public verification clients.
+     */
+    PublicDPPIntegrityResponse: {
+      /**
+       * Dpp Id
+       * Format: uuid
+       */
+      dpp_id: string;
+      /**
+       * Revision Id
+       * Format: uuid
+       */
+      revision_id: string;
+      /** Revision No */
+      revision_no: number;
+      /** Digest Sha256 */
+      digest_sha256: string;
+      /** Signed Jws */
+      signed_jws?: string | null;
+      /** Digestalgorithm */
+      digestAlgorithm: string;
+      /** Digestcanonicalization */
+      digestCanonicalization: string;
+      /** Signaturekid */
+      signatureKid?: string | null;
+      /** Verificationmethodurls */
+      verificationMethodUrls: string[];
+      anchor?: components["schemas"]["PublicIntegrityAnchorRef"] | null;
+    };
+    /**
      * PublicDPPResponse
      * @description Public response for a published DPP — no sensitive fields.
      */
@@ -4354,6 +6534,48 @@ export interface components {
       /** Eventlist */
       eventList: components["schemas"]["PublicEPCISEventResponse"][];
     };
+    /** PublicExportRequest */
+    PublicExportRequest: {
+      /** Template Key */
+      template_key: string;
+      /** Version */
+      version?: string | null;
+      /** Data */
+      data: {
+        [key: string]: unknown;
+      };
+      /**
+       * Format
+       * @enum {string}
+       */
+      format: "json" | "aasx" | "pdf";
+    };
+    /**
+     * PublicIntegrityAnchorRef
+     * @description Latest tenant audit anchor metadata exposed for external verification context.
+     */
+    PublicIntegrityAnchorRef: {
+      /**
+       * Anchor Id
+       * Format: uuid
+       */
+      anchor_id: string;
+      /** Merkle Root */
+      merkle_root: string;
+      /** First Sequence */
+      first_sequence: number;
+      /** Last Sequence */
+      last_sequence: number;
+      /** Created At */
+      created_at: string;
+      /** Signaturekid */
+      signatureKid?: string | null;
+      /**
+       * Tsatokenpresent
+       * @default false
+       */
+      tsaTokenPresent?: boolean;
+    };
     /**
      * PublicLandingSummaryResponse
      * @description Public aggregate metrics for the landing page.
@@ -4378,6 +6600,30 @@ export interface components {
       /** Refresh Sla Seconds */
       refresh_sla_seconds?: number | null;
     };
+    /** PublicPreviewRequest */
+    PublicPreviewRequest: {
+      /** Template Key */
+      template_key: string;
+      /** Version */
+      version?: string | null;
+      /** Data */
+      data: {
+        [key: string]: unknown;
+      };
+    };
+    /** PublicPreviewResponse */
+    PublicPreviewResponse: {
+      /** Template Key */
+      template_key: string;
+      /** Version */
+      version: string;
+      /** Aas Environment */
+      aas_environment: {
+        [key: string]: unknown;
+      };
+      /** Warnings */
+      warnings?: string[];
+    };
     /**
      * PublicShellDescriptorResponse
      * @description Public shell descriptor — excludes internal fields.
@@ -4397,6 +6643,71 @@ export interface components {
       submodel_descriptors: {
           [key: string]: unknown;
         }[];
+    };
+    /** PublicTemplateDetailResponse */
+    PublicTemplateDetailResponse: {
+      /** Template Key */
+      template_key: string;
+      /** Display Name */
+      display_name: string;
+      /** Catalog Status */
+      catalog_status: string;
+      /** Catalog Folder */
+      catalog_folder?: string | null;
+      /** Semantic Id */
+      semantic_id: string;
+      /** Latest Version */
+      latest_version: string;
+      /** Fetched At */
+      fetched_at: string;
+      source_metadata: components["schemas"]["TemplateSourceMetadataResponse"];
+      /** Versions */
+      versions?: {
+          [key: string]: unknown;
+        }[];
+    };
+    /** PublicTemplateListResponse */
+    PublicTemplateListResponse: {
+      /** Templates */
+      templates: components["schemas"]["PublicTemplateSummary"][];
+      /** Count */
+      count: number;
+      /**
+       * Status Filter
+       * @enum {string}
+       */
+      status_filter: "published" | "deprecated" | "all";
+      /** Search */
+      search?: string | null;
+    };
+    /** PublicTemplateSummary */
+    PublicTemplateSummary: {
+      /** Template Key */
+      template_key: string;
+      /** Display Name */
+      display_name: string;
+      /** Catalog Status */
+      catalog_status: string;
+      /** Catalog Folder */
+      catalog_folder?: string | null;
+      /** Semantic Id */
+      semantic_id: string;
+      /** Latest Version */
+      latest_version: string;
+      /** Fetched At */
+      fetched_at: string;
+      source_metadata: components["schemas"]["TemplateSourceMetadataResponse"];
+    };
+    /** PublicTemplateVersionsResponse */
+    PublicTemplateVersionsResponse: {
+      /** Template Key */
+      template_key: string;
+      /** Versions */
+      versions: {
+          [key: string]: unknown;
+        }[];
+      /** Count */
+      count: number;
     };
     /**
      * PublishResultResponse
@@ -4538,11 +6849,102 @@ export interface components {
         }[];
     };
     /**
+     * RegulatoryTimelineEvent
+     * @description Single verified timeline milestone.
+     */
+    RegulatoryTimelineEvent: {
+      /** Id */
+      id: string;
+      /** Date */
+      date: string;
+      /**
+       * Date Precision
+       * @enum {string}
+       */
+      date_precision: "day" | "month";
+      /**
+       * Track
+       * @enum {string}
+       */
+      track: "regulation" | "standards";
+      /** Title */
+      title: string;
+      /** Plain Summary */
+      plain_summary: string;
+      /** Audience Tags */
+      audience_tags?: string[];
+      /**
+       * Status
+       * @enum {string}
+       */
+      status: "past" | "today" | "upcoming";
+      /** Verified */
+      verified: boolean;
+      verification: components["schemas"]["RegulatoryTimelineVerification"];
+      /** Sources */
+      sources?: components["schemas"]["RegulatoryTimelineSource"][];
+    };
+    /**
+     * RegulatoryTimelineResponse
+     * @description Public response contract for landing timeline.
+     */
+    RegulatoryTimelineResponse: {
+      /** Generated At */
+      generated_at: string;
+      /** Fetched At */
+      fetched_at: string;
+      /**
+       * Source Status
+       * @enum {string}
+       */
+      source_status: "fresh" | "stale";
+      /** Refresh Sla Seconds */
+      refresh_sla_seconds: number;
+      /** Digest Sha256 */
+      digest_sha256: string;
+      /** Events */
+      events: components["schemas"]["RegulatoryTimelineEvent"][];
+    };
+    /**
+     * RegulatoryTimelineSource
+     * @description Official citation used to verify a timeline event.
+     */
+    RegulatoryTimelineSource: {
+      /** Label */
+      label: string;
+      /** Url */
+      url: string;
+      /** Publisher */
+      publisher: string;
+      /** Retrieved At */
+      retrieved_at: string;
+      /** Sha256 */
+      sha256?: string | null;
+    };
+    /**
+     * RegulatoryTimelineVerification
+     * @description Verification metadata for a timeline event.
+     */
+    RegulatoryTimelineVerification: {
+      /** Checked At */
+      checked_at: string;
+      /**
+       * Method
+       * @enum {string}
+       */
+      method: "source-hash" | "content-match" | "manual";
+      /**
+       * Confidence
+       * @enum {string}
+       */
+      confidence: "high" | "medium" | "low";
+    };
+    /**
      * RenderOutputType
      * @description Renderable file types for carrier artifacts.
      * @enum {string}
      */
-    RenderOutputType: "png" | "svg" | "pdf";
+    RenderOutputType: "png" | "svg" | "pdf" | "ndef";
     /**
      * RepairInvalidListsError
      * @description Per-DPP repair failure details.
@@ -4609,6 +7011,10 @@ export interface components {
     ResendVerificationResponse: {
       /** Queued */
       queued: boolean;
+      /** Cooldown Seconds */
+      cooldown_seconds: number;
+      /** Next Allowed At */
+      next_allowed_at?: string | null;
     };
     /**
      * ResolverDescriptionResponse
@@ -4869,6 +7275,10 @@ export interface components {
       reviewed_at?: string | null;
       /** Created At */
       created_at: string;
+      /** Requester Email */
+      requester_email?: string | null;
+      /** Requester Display Name */
+      requester_display_name?: string | null;
     };
     /**
      * RoleRequestReview
@@ -5280,6 +7690,15 @@ export interface components {
       id: string;
       /** Template Key */
       template_key: string;
+      /** Display Name */
+      display_name: string;
+      /**
+       * Catalog Status
+       * @default published
+       */
+      catalog_status?: string;
+      /** Catalog Folder */
+      catalog_folder?: string | null;
       /** Idta Version */
       idta_version: string;
       /** Resolved Version */
@@ -5334,6 +7753,12 @@ export interface components {
       selection_strategy?: string | null;
       /** Source Url */
       source_url: string;
+      /** Catalog Status */
+      catalog_status?: string | null;
+      /** Catalog Folder */
+      catalog_folder?: string | null;
+      /** Display Name */
+      display_name?: string | null;
     };
     /** TenantCreateRequest */
     TenantCreateRequest: {
@@ -5464,6 +7889,22 @@ export interface components {
       /** Name */
       name?: string | null;
       status?: components["schemas"]["TenantStatus"] | null;
+    };
+    /**
+     * TestConnectionResult
+     * @description Result of an OPC UA test-connection probe.
+     */
+    TestConnectionResult: {
+      /** Success */
+      success: boolean;
+      /** Serverinfo */
+      serverInfo?: {
+        [key: string]: unknown;
+      } | null;
+      /** Error */
+      error?: string | null;
+      /** Latencyms */
+      latencyMs?: number | null;
     };
     /**
      * TestResultResponse
@@ -5834,9 +8275,9 @@ export interface components {
     };
     /**
      * ActorSummary
-     * @description Actor identity summary for ownership metadata.
+     * @description Actor metadata for activity responses.
      */
-    app__modules__connectors__router__ActorSummary: {
+    app__modules__activity__router__ActorSummary: {
       /** Subject */
       subject: string;
       /** Display Name */
@@ -6008,6 +8449,32 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["PublicDPPResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Public Dpp Integrity Bundle
+   * @description Return integrity metadata for external digest/signature verification.
+   */
+  get_public_dpp_integrity_bundle_api_v1_public__tenant_slug__dpps__dpp_id__integrity_get: {
+    parameters: {
+      path: {
+        tenant_slug: string;
+        dpp_id: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PublicDPPIntegrityResponse"];
         };
       };
       /** @description Validation Error */
@@ -6479,6 +8946,22 @@ export interface operations {
     };
   };
   /**
+   * Get Public Jwks
+   * @description Return JWKS for public signature verification.
+   */
+  get_public_jwks_api_v1_public__well_known_jwks_json_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": {
+            [key: string]: unknown;
+          };
+        };
+      };
+    };
+  };
+  /**
    * Get Did Document
    * @description Return the DID Document for a tenant (public, no auth).
    *
@@ -6528,6 +9011,417 @@ export interface operations {
       422: {
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Latest Cirpass Stories
+   * @description Get latest CIRPASS user-story feed with stale-while-refresh behavior.
+   */
+  get_latest_cirpass_stories_api_v1_public_cirpass_stories_latest_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CirpassStoryFeedResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Latest Cirpass Lab Manifest
+   * @description Get latest validated CIRPASS lab scenario manifest.
+   */
+  get_latest_cirpass_lab_manifest_api_v1_public_cirpass_lab_manifest_latest_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CirpassLabManifestResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Cirpass Lab Manifest Version
+   * @description Get specific CIRPASS lab manifest version.
+   */
+  get_cirpass_lab_manifest_version_api_v1_public_cirpass_lab_manifest__manifest_version__get: {
+    parameters: {
+      path: {
+        manifest_version: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CirpassLabManifestResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Create Cirpass Session
+   * @description Create anonymous signed browser session for public leaderboard submissions.
+   */
+  create_cirpass_session_api_v1_public_cirpass_session_post: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CirpassSessionResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Cirpass Leaderboard
+   * @description Read public leaderboard rows for a CIRPASS story version.
+   */
+  get_cirpass_leaderboard_api_v1_public_cirpass_leaderboard_get: {
+    parameters: {
+      query?: {
+        version?: string | null;
+        limit?: number | null;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CirpassLeaderboardResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Submit Cirpass Leaderboard Score
+   * @description Submit a pseudonymous public score for the CIRPASS simulator.
+   */
+  submit_cirpass_leaderboard_score_api_v1_public_cirpass_leaderboard_submit_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CirpassLeaderboardSubmitRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CirpassLeaderboardSubmitResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Ingest Cirpass Lab Event
+   * @description Ingest anonymized CIRPASS lab telemetry events.
+   */
+  ingest_cirpass_lab_event_api_v1_public_cirpass_lab_events_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CirpassLabEventRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CirpassLabEventResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Public Regulatory Timeline
+   * @description Get latest verified public timeline with stale-while-refresh behavior.
+   */
+  get_public_regulatory_timeline_api_v1_public_landing_regulatory_timeline_get: {
+    parameters: {
+      query?: {
+        track?: "all" | "regulation" | "standards";
+      };
+      header?: {
+        "If-None-Match"?: string | null;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["RegulatoryTimelineResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** List Public Templates */
+  list_public_templates_api_v1_public_smt_templates_get: {
+    parameters: {
+      query?: {
+        status?: "published" | "deprecated" | "all";
+        search?: string | null;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PublicTemplateListResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Get Public Template */
+  get_public_template_api_v1_public_smt_templates__template_key__get: {
+    parameters: {
+      path: {
+        template_key: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PublicTemplateDetailResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** List Public Template Versions */
+  list_public_template_versions_api_v1_public_smt_templates__template_key__versions_get: {
+    parameters: {
+      path: {
+        template_key: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PublicTemplateVersionsResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Get Public Template Contract */
+  get_public_template_contract_api_v1_public_smt_templates__template_key__contract_get: {
+    parameters: {
+      query?: {
+        version?: string | null;
+      };
+      path: {
+        template_key: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["TemplateContractResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Preview Public Template Instance */
+  preview_public_template_instance_api_v1_public_smt_preview_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PublicPreviewRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PublicPreviewResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Export Public Template Instance */
+  export_public_template_instance_api_v1_public_smt_export_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PublicExportRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Public Read Dpp By Id */
+  PublicReadDPPById: {
+    parameters: {
+      path: {
+        tenant_slug: string;
+        dpp_id: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CENPublicDPPResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Public Search Dpps */
+  PublicSearchDPPs: {
+    parameters: {
+      query?: {
+        limit?: number;
+        cursor?: string | null;
+        identifier?: string | null;
+        scheme?: string | null;
+      };
+      path: {
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CENDPPSearchResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Reset Lab State
+   * @description Reset lab tenant fixtures to deterministic baseline (admin only).
+   */
+  reset_lab_state_api_v1_lab_reset_post: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["LabResetResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * Seed Lab State
+   * @description Seed deterministic fixtures required by a specific scenario (admin only).
+   */
+  seed_lab_state_api_v1_lab_seed_post: {
+    parameters: {
+      query?: {
+        scenario?: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["LabSeedResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Lab Status
+   * @description Inspect current deterministic sandbox state for live-mode readiness.
+   */
+  get_lab_status_api_v1_lab_status_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["LabStatusResponse"];
         };
       };
     };
@@ -6967,6 +9861,31 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["TemplateResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Sync Template Catalog
+   * @description Sync published/deprecated IDTA templates into DB cache (authenticated).
+   */
+  sync_template_catalog_api_v1_templates_catalog_sync_post: {
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["CatalogSyncRequest"] | null;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CatalogSyncResponse"];
         };
       };
       /** @description Validation Error */
@@ -7600,6 +10519,34 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["DPPDiffResult"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get GS1 Digital Link URI for a DPP
+   * @description Return the canonical GS1 Digital Link URI for a DPP with GTIN.
+   */
+  get_dpp_digital_link_api_v1_tenants__tenant_slug__dpps__dpp_id__digital_link_get: {
+    parameters: {
+      path: {
+        dpp_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": {
+            [key: string]: string | boolean | null;
+          };
         };
       };
       /** @description Validation Error */
@@ -9434,6 +12381,84 @@ export interface operations {
       };
     };
   };
+  /** Validate Data Carrier Payload */
+  validate_data_carrier_payload_api_v1_tenants__tenant_slug__data_carriers_validate_post: {
+    parameters: {
+      path: {
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["DataCarrierValidationRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["DataCarrierValidationResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Get Data Carrier Qa */
+  get_data_carrier_qa_api_v1_tenants__tenant_slug__data_carriers__carrier_id__qa_get: {
+    parameters: {
+      path: {
+        carrier_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["DataCarrierQAResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Create Data Carrier Quality Check */
+  create_data_carrier_quality_check_api_v1_tenants__tenant_slug__data_carriers__carrier_id__quality_checks_post: {
+    parameters: {
+      path: {
+        carrier_id: string;
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["DataCarrierQualityCheckCreateRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["DataCarrierQualityCheckResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
   /** Deprecate Data Carrier */
   deprecate_data_carrier_api_v1_tenants__tenant_slug__data_carriers__carrier_id__lifecycle_deprecate_post: {
     parameters: {
@@ -9566,6 +12591,554 @@ export interface operations {
       };
     };
   };
+  /** Validate Identifier */
+  validate_identifier_api_v1_tenants__tenant_slug__identifiers_validate_post: {
+    parameters: {
+      path: {
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["IdentifierValidateRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["IdentifierValidateResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** List Identifiers */
+  list_identifiers_api_v1_tenants__tenant_slug__identifiers_get: {
+    parameters: {
+      query?: {
+        entity_type?: components["schemas"]["IdentifierEntityType"] | null;
+        scheme_code?: string | null;
+        status?: string | null;
+        limit?: number;
+        offset?: number;
+      };
+      path: {
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ExternalIdentifierResponse"][];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Register Identifier */
+  register_identifier_api_v1_tenants__tenant_slug__identifiers_post: {
+    parameters: {
+      path: {
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["IdentifierRegisterRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["ExternalIdentifierResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Get Identifier */
+  get_identifier_api_v1_tenants__tenant_slug__identifiers__identifier_id__get: {
+    parameters: {
+      path: {
+        identifier_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ExternalIdentifierResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Supersede Identifier */
+  supersede_identifier_api_v1_tenants__tenant_slug__identifiers__identifier_id__supersede_post: {
+    parameters: {
+      path: {
+        identifier_id: string;
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["IdentifierSupersedeRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ExternalIdentifierResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** List Operators */
+  list_operators_api_v1_tenants__tenant_slug__identifiers_operators_get: {
+    parameters: {
+      query?: {
+        limit?: number;
+        offset?: number;
+      };
+      path: {
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["EconomicOperatorResponse"][];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Create Operator */
+  create_operator_api_v1_tenants__tenant_slug__identifiers_operators_post: {
+    parameters: {
+      path: {
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["EconomicOperatorCreateRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["EconomicOperatorResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** List Facilities */
+  list_facilities_api_v1_tenants__tenant_slug__identifiers_facilities_get: {
+    parameters: {
+      query?: {
+        operator_id?: string | null;
+        limit?: number;
+        offset?: number;
+      };
+      path: {
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["FacilityResponse"][];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Create Facility */
+  create_facility_api_v1_tenants__tenant_slug__identifiers_facilities_post: {
+    parameters: {
+      path: {
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["FacilityCreateRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["FacilityResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Search Dpps */
+  SearchDPPs: {
+    parameters: {
+      query?: {
+        limit?: number;
+        cursor?: string | null;
+        identifier?: string | null;
+        scheme?: string | null;
+        status?: string | null;
+      };
+      path: {
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CENDPPSearchResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Create Dpp */
+  CreateDPP: {
+    parameters: {
+      path: {
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CENCreateDPPRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["CENDPPResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Read Dpp By Id */
+  ReadDPPById: {
+    parameters: {
+      path: {
+        dpp_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CENDPPResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Archive Dpp */
+  ArchiveDPP: {
+    parameters: {
+      path: {
+        dpp_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CENDPPResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Update Dpp */
+  UpdateDPP: {
+    parameters: {
+      path: {
+        dpp_id: string;
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CENUpdateDPPRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CENDPPResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Read Dpp By Identifier */
+  ReadDPPByIdentifier: {
+    parameters: {
+      query: {
+        identifier: string;
+        scheme: string;
+      };
+      path: {
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CENDPPResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Publish Dpp */
+  PublishDPP: {
+    parameters: {
+      path: {
+        dpp_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CENDPPResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Validate Identifier */
+  ValidateIdentifier: {
+    parameters: {
+      path: {
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CENValidateIdentifierRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CENValidateIdentifierResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Register Identifier */
+  RegisterIdentifier: {
+    parameters: {
+      path: {
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CENRegisterIdentifierRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["CENExternalIdentifierResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Supersede Identifier */
+  SupersedeIdentifier: {
+    parameters: {
+      path: {
+        identifier_id: string;
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CENSupersedeIdentifierRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CENExternalIdentifierResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Sync Registry For Dpp */
+  SyncRegistryForDPP: {
+    parameters: {
+      path: {
+        dpp_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CENSyncResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Sync Resolver For Dpp */
+  SyncResolverForDPP: {
+    parameters: {
+      path: {
+        dpp_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CENSyncResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
   /**
    * Get Global Asset Id Base Uri
    * @description Get the current global asset ID base URI.
@@ -9644,6 +13217,20 @@ export interface operations {
       422: {
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Cen Profiles Diagnostics
+   * @description Return active CEN profile versions for diagnostics and contract debugging.
+   */
+  get_cen_profiles_diagnostics_api_v1_admin_settings_cen_profiles_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CENProfileDiagnosticsResponse"];
         };
       };
     };
@@ -9853,15 +13440,13 @@ export interface operations {
   };
   /**
    * Anchor Merkle Root
-   * @description Compute Merkle root and optionally sign it (admin only).
+   * @description Anchor the next unanchored audit batch (admin only).
    */
   anchor_merkle_root_api_v1_admin_audit_anchor_post: {
     parameters: {
       query: {
         /** @description Tenant ID to anchor */
         tenant_id: string;
-        /** @description Ed25519 private key PEM for signing (optional) */
-        signing_key_pem?: string | null;
       };
     };
     responses: {
@@ -11108,6 +14693,672 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["RoleRequestResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Opcua Feature Status
+   * @description Return whether OPC UA endpoints are enabled in this environment.
+   */
+  get_opcua_feature_status_api_v1_tenants__tenant_slug__opcua_status_get: {
+    parameters: {
+      path: {
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["OPCUAFeatureStatusResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * List Sources
+   * @description List OPC UA sources for the current tenant.
+   */
+  list_sources_api_v1_tenants__tenant_slug__opcua_sources_get: {
+    parameters: {
+      query?: {
+        offset?: number;
+        limit?: number;
+      };
+      path: {
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["OPCUASourceListResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Create Source
+   * @description Register a new OPC UA source.
+   */
+  create_source_api_v1_tenants__tenant_slug__opcua_sources_post: {
+    parameters: {
+      path: {
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["OPCUASourceCreate"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["OPCUASourceResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Source
+   * @description Get details of a single OPC UA source (password never exposed).
+   */
+  get_source_api_v1_tenants__tenant_slug__opcua_sources__source_id__get: {
+    parameters: {
+      path: {
+        source_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["OPCUASourceResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Delete Source
+   * @description Delete an OPC UA source and all related nodesets/mappings.
+   */
+  delete_source_api_v1_tenants__tenant_slug__opcua_sources__source_id__delete: {
+    parameters: {
+      path: {
+        source_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      204: {
+        content: never;
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Update Source
+   * @description Update an existing OPC UA source.
+   */
+  update_source_api_v1_tenants__tenant_slug__opcua_sources__source_id__patch: {
+    parameters: {
+      path: {
+        source_id: string;
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["OPCUASourceUpdate"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["OPCUASourceResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Test Connection
+   * @description Test connectivity to an OPC UA endpoint (3s timeout).
+   */
+  test_connection_api_v1_tenants__tenant_slug__opcua_sources__source_id__test_connection_post: {
+    parameters: {
+      path: {
+        source_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["TestConnectionResult"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * List Nodesets
+   * @description List uploaded NodeSets, optionally filtered by source.
+   */
+  list_nodesets_api_v1_tenants__tenant_slug__opcua_nodesets_get: {
+    parameters: {
+      query?: {
+        sourceId?: string | null;
+        offset?: number;
+        limit?: number;
+      };
+      path: {
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["OPCUANodeSetListResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Upload Nodeset
+   * @description Upload a NodeSet2.xml, parse it, and store metadata + file.
+   */
+  upload_nodeset_api_v1_tenants__tenant_slug__opcua_nodesets_upload_post: {
+    parameters: {
+      query?: {
+        sourceId?: string | null;
+        companionSpecName?: string | null;
+        companionSpecVersion?: string | null;
+      };
+      path: {
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "multipart/form-data": components["schemas"]["Body_upload_nodeset_api_v1_tenants__tenant_slug__opcua_nodesets_upload_post"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["OPCUANodeSetResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Nodeset
+   * @description Get full detail of a NodeSet including parsed node graph.
+   */
+  get_nodeset_api_v1_tenants__tenant_slug__opcua_nodesets__nodeset_id__get: {
+    parameters: {
+      path: {
+        nodeset_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["OPCUANodeSetDetailResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Delete Nodeset
+   * @description Delete a NodeSet from DB and object storage.
+   */
+  delete_nodeset_api_v1_tenants__tenant_slug__opcua_nodesets__nodeset_id__delete: {
+    parameters: {
+      path: {
+        nodeset_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      204: {
+        content: never;
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Download Nodeset
+   * @description Generate a presigned download URL for the NodeSet XML.
+   */
+  download_nodeset_api_v1_tenants__tenant_slug__opcua_nodesets__nodeset_id__download_get: {
+    parameters: {
+      path: {
+        nodeset_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": {
+            [key: string]: string;
+          };
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Search Nodeset Nodes
+   * @description Search the parsed node graph of a NodeSet.
+   */
+  search_nodeset_nodes_api_v1_tenants__tenant_slug__opcua_nodesets__nodeset_id__nodes_get: {
+    parameters: {
+      query: {
+        /** @description Search query */
+        q: string;
+        nodeClass?: string | null;
+        limit?: number;
+      };
+      path: {
+        nodeset_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["NodeSearchResult"][];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * List Mappings
+   * @description List OPC UA mappings with optional filters.
+   */
+  list_mappings_api_v1_tenants__tenant_slug__opcua_mappings_get: {
+    parameters: {
+      query?: {
+        sourceId?: string | null;
+        mappingType?: components["schemas"]["OPCUAMappingType"] | null;
+        isEnabled?: boolean | null;
+        offset?: number;
+        limit?: number;
+      };
+      path: {
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["OPCUAMappingListResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Create Mapping
+   * @description Create a new OPC UA → AAS/EPCIS mapping.
+   */
+  create_mapping_api_v1_tenants__tenant_slug__opcua_mappings_post: {
+    parameters: {
+      path: {
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["OPCUAMappingCreate"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["OPCUAMappingResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Mapping
+   * @description Get details of a single mapping.
+   */
+  get_mapping_api_v1_tenants__tenant_slug__opcua_mappings__mapping_id__get: {
+    parameters: {
+      path: {
+        mapping_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["OPCUAMappingResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Delete Mapping
+   * @description Delete a mapping.
+   */
+  delete_mapping_api_v1_tenants__tenant_slug__opcua_mappings__mapping_id__delete: {
+    parameters: {
+      path: {
+        mapping_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      204: {
+        content: never;
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Update Mapping
+   * @description Update an existing mapping.
+   */
+  update_mapping_api_v1_tenants__tenant_slug__opcua_mappings__mapping_id__patch: {
+    parameters: {
+      path: {
+        mapping_id: string;
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["OPCUAMappingUpdate"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["OPCUAMappingResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Validate Mapping
+   * @description Validate a mapping's NodeId, AAS path, SAMM URN, and transform expression.
+   */
+  validate_mapping_api_v1_tenants__tenant_slug__opcua_mappings__mapping_id__validate_post: {
+    parameters: {
+      path: {
+        mapping_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["MappingValidationResult"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Dry Run Mapping
+   * @description Preview the effect of a mapping against a DPP revision (no DB writes).
+   */
+  dry_run_mapping_api_v1_tenants__tenant_slug__opcua_mappings__mapping_id__dry_run_post: {
+    parameters: {
+      path: {
+        mapping_id: string;
+        tenant_slug: string;
+      };
+    };
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["DryRunRequest"] | null;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["MappingDryRunResult"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Queue a DPP for dataspace publication */
+  publish_to_dataspace_api_v1_tenants__tenant_slug__opcua_dataspace_publish_post: {
+    parameters: {
+      path: {
+        tenant_slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["DataspacePublishRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["DataspacePublicationJobResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** List dataspace publication jobs */
+  list_publication_jobs_api_v1_tenants__tenant_slug__opcua_dataspace_jobs_get: {
+    parameters: {
+      query?: {
+        dppId?: string | null;
+        offset?: number;
+        limit?: number;
+      };
+      path: {
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["DataspacePublicationJobListResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Get a publication job */
+  get_publication_job_api_v1_tenants__tenant_slug__opcua_dataspace_jobs__job_id__get: {
+    parameters: {
+      path: {
+        job_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["DataspacePublicationJobResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Retry a failed publication job */
+  retry_publication_job_api_v1_tenants__tenant_slug__opcua_dataspace_jobs__job_id__retry_post: {
+    parameters: {
+      path: {
+        job_id: string;
+        tenant_slug: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["DataspacePublicationJobResponse"];
         };
       };
       /** @description Validation Error */

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -311,3 +311,22 @@ export type DataCarrierListResponse = components['schemas']['DataCarrierListResp
 export type DataCarrierPreSalePackResponse = components['schemas']['DataCarrierPreSalePackResponse'];
 export type DataCarrierRegistryExportResponse =
   components['schemas']['DataCarrierRegistryExportResponse'];
+export type DataCarrierValidationRequest =
+  components['schemas']['DataCarrierValidationRequest'];
+export type DataCarrierValidationResponse =
+  components['schemas']['DataCarrierValidationResponse'];
+export type DataCarrierQAResponse = components['schemas']['DataCarrierQAResponse'];
+export type DataCarrierQualityCheckCreateRequest =
+  components['schemas']['DataCarrierQualityCheckCreateRequest'];
+export type DataCarrierQualityCheckResponse =
+  components['schemas']['DataCarrierQualityCheckResponse'];
+
+// CEN facade types
+export type CENDPPResponse = components['schemas']['CENDPPResponse'];
+export type CENDPPSearchResponse = components['schemas']['CENDPPSearchResponse'];
+export type CENPublicDPPResponse = components['schemas']['CENPublicDPPResponse'];
+export type CENSyncResponse = components['schemas']['CENSyncResponse'];
+export type CENValidateIdentifierResponse =
+  components['schemas']['CENValidateIdentifierResponse'];
+export type CENExternalIdentifierResponse =
+  components['schemas']['CENExternalIdentifierResponse'];

--- a/frontend/src/features/publisher/hooks/useDataCarriersApi.ts
+++ b/frontend/src/features/publisher/hooks/useDataCarriersApi.ts
@@ -4,11 +4,16 @@ import type {
   DataCarrierDeprecateRequest,
   DataCarrierListResponse,
   DataCarrierPreSalePackResponse,
+  DataCarrierQAResponse,
+  DataCarrierQualityCheckCreateRequest,
+  DataCarrierQualityCheckResponse,
   DataCarrierRegistryExportResponse,
   DataCarrierRenderRequest,
   DataCarrierReissueRequest,
   DataCarrierResponse,
   DataCarrierUpdateRequest,
+  DataCarrierValidationRequest,
+  DataCarrierValidationResponse,
   DataCarrierWithdrawRequest,
 } from '@/api/types';
 import { getApiErrorMessage, tenantApiFetch } from '@/lib/api';
@@ -114,6 +119,57 @@ export function useDataCarriersApi(token?: string) {
     [token]
   );
 
+  const validateCarrierPayload = useCallback(
+    async (
+      payload: DataCarrierValidationRequest
+    ): Promise<DataCarrierValidationResponse> => {
+      const response = await tenantApiFetch(
+        '/data-carriers/validate',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        },
+        token
+      );
+      return parseJsonOrThrow<DataCarrierValidationResponse>(
+        response,
+        'Failed to validate carrier payload'
+      );
+    },
+    [token]
+  );
+
+  const getCarrierQa = useCallback(
+    async (carrierId: string): Promise<DataCarrierQAResponse> => {
+      const response = await tenantApiFetch(`/data-carriers/${carrierId}/qa`, {}, token);
+      return parseJsonOrThrow<DataCarrierQAResponse>(response, 'Failed to load carrier QA');
+    },
+    [token]
+  );
+
+  const createQualityCheck = useCallback(
+    async (
+      carrierId: string,
+      payload: DataCarrierQualityCheckCreateRequest
+    ): Promise<DataCarrierQualityCheckResponse> => {
+      const response = await tenantApiFetch(
+        `/data-carriers/${carrierId}/quality-checks`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        },
+        token
+      );
+      return parseJsonOrThrow<DataCarrierQualityCheckResponse>(
+        response,
+        'Failed to create quality check'
+      );
+    },
+    [token]
+  );
+
   const deprecateCarrier = useCallback(
     async (
       carrierId: string,
@@ -205,6 +261,9 @@ export function useDataCarriersApi(token?: string) {
     getCarrier,
     updateCarrier,
     renderCarrier,
+    validateCarrierPayload,
+    getCarrierQa,
+    createQualityCheck,
     deprecateCarrier,
     withdrawCarrier,
     reissueCarrier,
@@ -212,4 +271,3 @@ export function useDataCarriersApi(token?: string) {
     exportRegistry,
   };
 }
-

--- a/frontend/src/features/publisher/pages/__tests__/DataCarriersPage.test.tsx
+++ b/frontend/src/features/publisher/pages/__tests__/DataCarriersPage.test.tsx
@@ -59,6 +59,18 @@ describe('DataCarriersPage', () => {
       if (path.startsWith('/data-carriers?')) {
         return Promise.resolve(jsonResponse({ items: [], count: 0 }));
       }
+      if (path === '/data-carriers/validate' && options?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse({
+            valid: true,
+            warnings: [],
+            details: {
+              carrierType: 'qr',
+              payloadLength: 28,
+            },
+          }),
+        );
+      }
       if (path === '/data-carriers' && options?.method === 'POST') {
         return Promise.resolve(
           jsonResponse({
@@ -82,6 +94,16 @@ describe('DataCarriersPage', () => {
           ok: true,
           blob: () => Promise.resolve(new Blob(['rendered'])),
         });
+      }
+      if (path === '/data-carriers/carrier-1/qa') {
+        return Promise.resolve(
+          jsonResponse({
+            carrier_id: 'carrier-1',
+            checks: [],
+            pass: true,
+            warnings: [],
+          }),
+        );
       }
       if (path === '/qr/dpp-1/carrier' && options?.method === 'POST') {
         return Promise.resolve({

--- a/infra/opa/policies/dpp.rego
+++ b/infra/opa/policies/dpp.rego
@@ -135,6 +135,48 @@ policy_candidate contains {
 }
 
 policy_candidate contains {
+    "priority": 97,
+    "decision": {
+        "effect": "allow",
+        "policy_id": "identifier-read-write",
+    },
+} if {
+    not input.subject.is_admin
+    input.action in ["create", "read", "update", "list"]
+    input.resource.type == "identifier"
+    input.subject.is_publisher
+    tenant_match
+}
+
+policy_candidate contains {
+    "priority": 98,
+    "decision": {
+        "effect": "allow",
+        "policy_id": "economic-operator-read-write",
+    },
+} if {
+    not input.subject.is_admin
+    input.action in ["create", "read", "update", "list"]
+    input.resource.type == "economic_operator"
+    input.subject.is_publisher
+    tenant_match
+}
+
+policy_candidate contains {
+    "priority": 99,
+    "decision": {
+        "effect": "allow",
+        "policy_id": "facility-read-write",
+    },
+} if {
+    not input.subject.is_admin
+    input.action in ["create", "read", "update", "list"]
+    input.resource.type == "facility"
+    input.subject.is_publisher
+    tenant_match
+}
+
+policy_candidate contains {
     "priority": 100,
     "decision": {
         "effect": "allow",


### PR DESCRIPTION
## Summary
- add feature-flagged, versioned CEN profile infrastructure for prEN 18219/18220/18222
- implement identifier governance (schemes, canonicalization/validation/register/supersede) plus lean operator/facility entities
- extend data-carrier capabilities with preflight validation, QA checks, payload hashing/binding, and QR/DataMatrix/NFC renderer dispatch
- add tenant/public CEN API facade with stable operation IDs, cursor-first search, identifier read/search endpoints, publish/archive/sync actions, and standards profile header
- wire CEN routes conditionally, update OPA policies, and update admin/publisher UI flows + generated OpenAPI types
- add migrations (0041-0044) and unit tests for CEN profiles, API contracts/services, carrier behavior, and RLS coverage
- add rollout follow-through artifacts:
  - `backend/tools/backfill_cen_identifiers.py` for idempotent tenant backfill
  - `docs/public/operations/cen-pren-rollout.md` with phased deployment checklist

## Validation
- `cd backend && uv run ruff check .`
- `cd backend && uv run mypy app`
- `cd frontend && npm run typecheck`
- `cd backend && uv run pytest tests/unit/test_cen_api_openapi.py tests/unit/test_cen_api_service.py tests/unit/test_cen_profiles.py tests/unit/test_data_carrier_cen.py tests/unit/test_identifiers.py tests/unit/test_tenant_rls_coverage.py -q`
- `cd backend && uv run ruff check tools/backfill_cen_identifiers.py`
- `cd backend && uv run python tools/backfill_cen_identifiers.py --help`
- `npx markdownlint-cli2 'docs/public/operations/cen-pren-rollout.md' 'docs/public/operations/README.md'`

## Notes
- CEN routes are mounted only when `cen_dpp_enabled=true`
- DataMatrix rendering returns deterministic `501` when runtime dependency is unavailable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CEN identifier governance: validate/register identifiers for products, operators, facilities; operator & facility management
  * Data carrier QA & validation: preflight checks, QA reports, and quality‑check creation
  * Public CEN read/search API for DPPs with identifier filtering; new tenant-scoped identifier APIs
  * Publisher UI/workflows: preflight validation before carrier creation, QA display and refresh

* **Documentation**
  * Added CEN prEN rollout operational guide and admin diagnostics for active CEN profiles
<!-- end of auto-generated comment: release notes by coderabbit.ai -->