### PR TITLE
[codex] Add template contract diagnostics

### DIFF
--- a/frontend/src/features/devtools/__tests__/PublicIdtaSubmodelEditorPage.test.tsx
+++ b/frontend/src/features/devtools/__tests__/PublicIdtaSubmodelEditorPage.test.tsx
@@ -415,13 +415,13 @@ describe('PublicIdtaSubmodelEditorPage', () => {
     renderPage();
 
     await waitFor(() => {
-      expect(screen.getByText(/Template diagnostics/i)).toBeTruthy();
+      expect(screen.getByText(/Template contract needs review/i)).toBeTruthy();
       expect(screen.getByText(/Unsupported nodes: 1/i)).toBeTruthy();
       expect(screen.getByText(/Unresolved drop-ins: 1/i)).toBeTruthy();
     });
 
-    expect(document.body.textContent).toContain('unsupported_model_type:SubmodelElement');
-    expect(document.body.textContent).toContain('source_not_found');
+    expect(document.body.textContent).toContain('Unsupported model type: SubmodelElement');
+    expect(document.body.textContent).toContain('source not found');
   });
 
   it('seeds required list structure from schema so Carbon Footprint starts aligned', async () => {

--- a/frontend/src/features/devtools/pages/PublicIdtaSubmodelEditorPage.tsx
+++ b/frontend/src/features/devtools/pages/PublicIdtaSubmodelEditorPage.tsx
@@ -15,6 +15,7 @@ import { useSubmodelForm } from '@/features/editor/hooks/useSubmodelForm';
 import { AASRendererList } from '@/features/editor/components/AASRenderer';
 import { JsonEditor } from '@/features/editor/components/JsonEditor';
 import { SubmodelEditorShell } from '@/features/editor/components/SubmodelEditorShell';
+import { TemplateContractDiagnostics } from '@/features/editor/components/TemplateContractDiagnostics';
 import type { TemplateContractResponse, TemplateDefinition } from '@/features/editor/types/definition';
 import type { UISchema } from '@/features/editor/types/uiSchema';
 import { defaultValueForSchema } from '@/features/editor/utils/formDefaults';
@@ -270,18 +271,6 @@ export default function PublicIdtaSubmodelEditorPage() {
   const { form } = useSubmodelForm(templateDefinition, uiSchema, emptyInitialData);
   const initialTemplateData = useMemo(() => buildInitialTemplateData(uiSchema), [uiSchema]);
   const hasDefinitionElements = Boolean(templateDefinition?.submodel?.elements?.length);
-  const diagnostics = useMemo(() => {
-    const unsupported = contractQuery.data?.unsupported_nodes ?? [];
-    const report = contractQuery.data?.dropin_resolution_report ?? [];
-    const unresolved = report.filter((entry) => {
-      if (!entry || typeof entry !== 'object') return false;
-      const statusValue = (entry as { status?: unknown }).status;
-      const status = typeof statusValue === 'string' ? statusValue.toLowerCase() : '';
-      return status !== 'resolved' && status !== 'skipped';
-    });
-    return { unsupported, unresolved };
-  }, [contractQuery.data?.dropin_resolution_report, contractQuery.data?.unsupported_nodes]);
-
   const syncDraftList = () => setDrafts(listSmtDrafts());
 
   const applyDraft = (draft: SmtDraftRecord) => {
@@ -748,32 +737,11 @@ export default function PublicIdtaSubmodelEditorPage() {
           )}
 
           {contractQuery.data && (
-            <div className="space-y-2 rounded-md border bg-muted/25 p-3 text-xs">
-              <p className="font-medium">Template diagnostics</p>
-              <div className="flex flex-wrap gap-2">
-                <Badge variant={diagnostics.unsupported.length > 0 ? 'destructive' : 'secondary'}>
-                  Unsupported nodes: {diagnostics.unsupported.length}
-                </Badge>
-                <Badge variant={diagnostics.unresolved.length > 0 ? 'destructive' : 'secondary'}>
-                  Unresolved drop-ins: {diagnostics.unresolved.length}
-                </Badge>
-              </div>
-              {diagnostics.unsupported.slice(0, 3).map((entry, index) => (
-                <p key={`unsupported-${entry.path ?? 'root'}-${index}`} className="text-muted-foreground">
-                  {(entry.path ?? 'root')}: {(entry.reasons ?? []).join(', ') || 'unsupported'}
-                </p>
-              ))}
-              {diagnostics.unresolved.slice(0, 3).map((entry, index) => {
-                const record = entry as Record<string, unknown>;
-                const pathValue = typeof record.path === 'string' ? record.path : 'root';
-                const reasonValue = typeof record.reason === 'string' ? record.reason : 'unresolved';
-                return (
-                  <p key={`unresolved-${pathValue}-${index}`} className="text-muted-foreground">
-                    {pathValue}: {reasonValue}
-                  </p>
-                );
-              })}
-            </div>
+            <TemplateContractDiagnostics
+              unsupportedNodes={contractQuery.data.unsupported_nodes}
+              dropinResolutionReport={contractQuery.data.dropin_resolution_report}
+              mode="sandbox"
+            />
           )}
 
           <div className="space-y-2 rounded-md border p-3">

--- a/frontend/src/features/editor/components/TemplateContractDiagnostics.test.tsx
+++ b/frontend/src/features/editor/components/TemplateContractDiagnostics.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TemplateContractDiagnostics } from './TemplateContractDiagnostics';
+
+describe('TemplateContractDiagnostics', () => {
+  it('shows a ready state when the contract has full editor coverage', () => {
+    render(<TemplateContractDiagnostics unsupportedNodes={[]} dropinResolutionReport={[]} />);
+
+    expect(screen.getByText('Template contract ready')).toBeTruthy();
+    expect(screen.getByText('Unsupported nodes: 0')).toBeTruthy();
+    expect(screen.getByText('Unresolved drop-ins: 0')).toBeTruthy();
+  });
+
+  it('explains DPP impact without incorrectly blocking draft save', () => {
+    render(
+      <TemplateContractDiagnostics
+        unsupportedNodes={[
+          {
+            path: 'Nameplate/BinaryPayload',
+            idShort: 'BinaryPayload',
+            modelType: 'Blob',
+            reasons: ['unsupported_model_type:Blob'],
+          },
+        ]}
+        dropinResolutionReport={[
+          {
+            status: 'missing',
+            reason: 'source_template_not_cached',
+            path: 'Nameplate/Address',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Template contract needs review')).toBeTruthy();
+    expect(screen.getByText('Unsupported nodes: 1')).toBeTruthy();
+    expect(screen.getByText('Unresolved drop-ins: 1')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Draft save remains available. Publishing can be blocked until the listed paths are supported.',
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText(/Nameplate\/BinaryPayload: Unsupported model type: Blob/i)).toBeTruthy();
+    expect(screen.getByText(/Nameplate\/Address: source template not cached/i)).toBeTruthy();
+  });
+
+  it('uses sandbox-specific impact text for public template previews', () => {
+    render(
+      <TemplateContractDiagnostics
+        mode="sandbox"
+        unsupportedNodes={[
+          {
+            path: 'Nameplate/Operation',
+            idShort: 'Operation',
+            modelType: 'Operation',
+            reasons: ['unsupported_model_type:Operation'],
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText('Preview and export may fail or require JSON edits for the listed paths.'),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/features/editor/components/TemplateContractDiagnostics.tsx
+++ b/frontend/src/features/editor/components/TemplateContractDiagnostics.tsx
@@ -1,0 +1,127 @@
+import { AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type { TemplateContractResponse } from '../types/definition';
+
+type UnsupportedNode = NonNullable<TemplateContractResponse['unsupported_nodes']>[number];
+type DropInReportEntry = Record<string, unknown>;
+
+type TemplateContractDiagnosticsProps = {
+  unsupportedNodes?: TemplateContractResponse['unsupported_nodes'];
+  dropinResolutionReport?: TemplateContractResponse['dropin_resolution_report'];
+  mode?: 'dpp' | 'sandbox';
+  maxItems?: number;
+  className?: string;
+};
+
+function normalizeReason(reason: unknown): string {
+  if (typeof reason !== 'string' || !reason.trim()) return 'unsupported';
+  return reason
+    .replace(/^unsupported_model_type:/, 'Unsupported model type: ')
+    .replace(/^schema_/, 'Schema issue: ')
+    .replace(/^dropin_/, 'Drop-in issue: ')
+    .replace(/_/g, ' ');
+}
+
+function pathLabel(value: unknown): string {
+  return typeof value === 'string' && value.trim() ? value : 'root';
+}
+
+function statusLabel(value: unknown): string {
+  return typeof value === 'string' && value.trim() ? normalizeReason(value) : 'unresolved';
+}
+
+function unresolvedDropIns(
+  report?: TemplateContractResponse['dropin_resolution_report'],
+): DropInReportEntry[] {
+  if (!Array.isArray(report)) return [];
+  return report.filter((entry): entry is DropInReportEntry => {
+    if (!entry || typeof entry !== 'object') return false;
+    const status = String((entry as DropInReportEntry).status ?? '').toLowerCase();
+    return Boolean(status) && status !== 'resolved' && status !== 'skipped';
+  });
+}
+
+function unsupportedReason(node: UnsupportedNode): string {
+  const reasons = Array.isArray(node.reasons) ? node.reasons : [];
+  return reasons.map(normalizeReason).join(', ') || 'unsupported';
+}
+
+export function TemplateContractDiagnostics({
+  unsupportedNodes = [],
+  dropinResolutionReport = [],
+  mode = 'dpp',
+  maxItems = 4,
+  className,
+}: TemplateContractDiagnosticsProps) {
+  const unsupported = Array.isArray(unsupportedNodes) ? unsupportedNodes : [];
+  const unresolved = unresolvedDropIns(dropinResolutionReport);
+  const hasIssues = unsupported.length > 0 || unresolved.length > 0;
+  const hiddenCount =
+    Math.max(unsupported.length - maxItems, 0) + Math.max(unresolved.length - maxItems, 0);
+  const impactText =
+    mode === 'sandbox'
+      ? 'Preview and export may fail or require JSON edits for the listed paths.'
+      : 'Draft save remains available. Publishing can be blocked until the listed paths are supported.';
+
+  return (
+    <section
+      aria-label="Template contract diagnostics"
+      className={cn(
+        'rounded-md border p-3 text-xs',
+        hasIssues ? 'border-amber-300 bg-amber-50 text-amber-950' : 'bg-muted/25',
+        className,
+      )}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        {hasIssues ? (
+          <AlertTriangle className="h-4 w-4 text-amber-700" aria-hidden="true" />
+        ) : (
+          <CheckCircle2 className="h-4 w-4 text-emerald-700" aria-hidden="true" />
+        )}
+        <p className="font-medium">
+          {hasIssues ? 'Template contract needs review' : 'Template contract ready'}
+        </p>
+        <Badge variant={unsupported.length > 0 ? 'destructive' : 'secondary'}>
+          Unsupported nodes: {unsupported.length}
+        </Badge>
+        <Badge variant={unresolved.length > 0 ? 'destructive' : 'secondary'}>
+          Unresolved drop-ins: {unresolved.length}
+        </Badge>
+      </div>
+
+      {hasIssues ? (
+        <>
+          <p className="mt-2 text-amber-900/80">{impactText}</p>
+          <div className="mt-2 space-y-1">
+            {unsupported.slice(0, maxItems).map((entry, index) => (
+              <p
+                key={`unsupported-${pathLabel(entry.path)}-${index}`}
+                className="break-words font-mono text-[11px] text-amber-900/80"
+              >
+                {pathLabel(entry.path)}: {unsupportedReason(entry)}
+              </p>
+            ))}
+            {unresolved.slice(0, maxItems).map((entry, index) => (
+              <p
+                key={`unresolved-${pathLabel(entry.path)}-${index}`}
+                className="break-words font-mono text-[11px] text-amber-900/80"
+              >
+                {pathLabel(entry.path)}: {statusLabel(entry.reason ?? entry.status)}
+              </p>
+            ))}
+          </div>
+          {hiddenCount > 0 && (
+            <p className="mt-2 text-amber-900/80">
+              {hiddenCount} more diagnostics hidden.
+            </p>
+          )}
+        </>
+      ) : (
+        <p className="mt-2 text-muted-foreground">
+          All loaded template paths have editor coverage.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/features/editor/pages/SubmodelEditorPage.tsx
+++ b/frontend/src/features/editor/pages/SubmodelEditorPage.tsx
@@ -53,6 +53,7 @@ import { AASRendererList } from '../components/AASRenderer';
 import { JsonEditor } from '../components/JsonEditor';
 import { FormToolbar } from '../components/FormToolbar';
 import { SubmodelEditorShell } from '../components/SubmodelEditorShell';
+import { TemplateContractDiagnostics } from '../components/TemplateContractDiagnostics';
 import { cn } from '@/lib/utils';
 import { DppOutlinePane } from '@/features/dpp-outline/components/DppOutlinePane';
 import { buildSubmodelEditorOutline } from '@/features/dpp-outline/builders/buildSubmodelEditorOutline';
@@ -69,14 +70,6 @@ class AmbiguousBindingError extends Error {
     this.candidates = candidates;
   }
 }
-
-type UnsupportedContractNode = {
-  path?: string | null;
-  idShort?: string | null;
-  modelType?: string | null;
-  semanticId?: string | null;
-  reasons?: string[];
-};
 
 function flattenFormErrors(
   errors: Record<string, unknown>,
@@ -494,12 +487,6 @@ export default function SubmodelEditorPage() {
 
   const uiSchema = contract?.schema as UISchema | undefined;
   const templateDefinition = contract?.definition as TemplateDefinition | undefined;
-  const unsupportedNodes = useMemo<UnsupportedContractNode[]>(() => {
-    const raw = contract?.unsupported_nodes;
-    if (!Array.isArray(raw)) return [];
-    return raw.filter((entry): entry is UnsupportedContractNode => typeof entry === 'object' && entry !== null);
-  }, [contract?.unsupported_nodes]);
-  const hasUnsupportedNodes = unsupportedNodes.length > 0;
   const saveDisabledReason = null;
 
   // ── React Hook Form ──
@@ -1010,13 +997,12 @@ export default function SubmodelEditorPage() {
               </AlertDescription>
             </Alert>
           )}
-          {hasUnsupportedNodes && (
-            <Alert>
-              <AlertDescription className="text-xs">
-                Unsupported template nodes detected ({unsupportedNodes.length}). Save and publish
-                are blocked until renderer support is added for these nodes.
-              </AlertDescription>
-            </Alert>
+          {contract && (
+            <TemplateContractDiagnostics
+              unsupportedNodes={contract.unsupported_nodes}
+              dropinResolutionReport={contract.dropin_resolution_report}
+              mode="dpp"
+            />
           )}
           {hasAmbiguousTemplateBindings && (
             <Alert variant="destructive">


### PR DESCRIPTION
## Summary
- add a shared template contract diagnostics panel for unsupported nodes and unresolved drop-ins
- reuse the panel in both the authenticated DPP submodel editor and public IDTA sandbox
- correct the DPP editor message so draft save is shown as available while publishing may be blocked

## Validation
- npm test -- --run src/features/editor/components/TemplateContractDiagnostics.test.tsx src/features/devtools/__tests__/PublicIdtaSubmodelEditorPage.test.tsx src/features/devtools/__tests__/submodelEditorRegression.test.tsx
- npm run typecheck
- npm run lint

## Notes
- Local API at localhost:8000 was not reachable from the shell, so validation used repository tests and static checks.