### PR TITLE
Add progressive-disclosure UX for Mini DPP

### DIFF
--- a/frontend/src/features/devtools/__tests__/PublicIdtaSubmodelEditorPage.test.tsx
+++ b/frontend/src/features/devtools/__tests__/PublicIdtaSubmodelEditorPage.test.tsx
@@ -44,6 +44,7 @@ describe('PublicIdtaSubmodelEditorPage', () => {
     window.localStorage.removeItem(SMT_DRAFT_STORAGE_KEY);
     window.localStorage.removeItem('publicSmt.autoPreview.enabled');
     window.localStorage.removeItem('publicSmt.autoPreview.background');
+    window.localStorage.removeItem('miniDpp.publicSmt.technicalDetails');
 
     Object.defineProperty(URL, 'createObjectURL', {
       configurable: true,
@@ -264,7 +265,7 @@ describe('PublicIdtaSubmodelEditorPage', () => {
     fireEvent.click(screen.getByText(/ManufacturerName: Required/i));
 
     await waitFor(() => {
-      expect(screen.getByRole('tab', { name: /Form/i }).getAttribute('data-state')).toBe('active');
+      expect(screen.getByRole('tab', { name: /Guided Form/i }).getAttribute('data-state')).toBe('active');
     });
   });
 
@@ -413,6 +414,12 @@ describe('PublicIdtaSubmodelEditorPage', () => {
     });
 
     renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Technical details/i })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Technical details/i }));
 
     await waitFor(() => {
       expect(screen.getByText(/Template diagnostics/i)).toBeTruthy();

--- a/frontend/src/features/devtools/__tests__/submodelEditorRegression.test.tsx
+++ b/frontend/src/features/devtools/__tests__/submodelEditorRegression.test.tsx
@@ -36,6 +36,7 @@ function okJson(data: unknown) {
 describe('SubmodelEditorPage regression', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
 
     apiFetchMock.mockImplementation((path: string) => {
       if (path === '/api/v1/templates/digital-nameplate') {
@@ -89,7 +90,7 @@ describe('SubmodelEditorPage regression', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/Submodel Data/i)).toBeTruthy();
+      expect(screen.getByRole('heading', { name: /Guided Submodel Form/i })).toBeTruthy();
     });
   });
 });

--- a/frontend/src/features/devtools/pages/PublicIdtaSubmodelEditorPage.tsx
+++ b/frontend/src/features/devtools/pages/PublicIdtaSubmodelEditorPage.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { Download, FileUp, RefreshCw } from 'lucide-react';
+import { ChevronDown, Download, FileUp, RefreshCw } from 'lucide-react';
 import { PageHeader } from '@/components/page-header';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -15,6 +16,7 @@ import { useSubmodelForm } from '@/features/editor/hooks/useSubmodelForm';
 import { AASRendererList } from '@/features/editor/components/AASRenderer';
 import { JsonEditor } from '@/features/editor/components/JsonEditor';
 import { SubmodelEditorShell } from '@/features/editor/components/SubmodelEditorShell';
+import { useDisclosurePreference } from '@/features/progressive-disclosure/useDisclosurePreference';
 import type { TemplateContractResponse, TemplateDefinition } from '@/features/editor/types/definition';
 import type { UISchema } from '@/features/editor/types/uiSchema';
 import { defaultValueForSchema } from '@/features/editor/utils/formDefaults';
@@ -201,6 +203,9 @@ export default function PublicIdtaSubmodelEditorPage() {
   );
   const [drafts, setDrafts] = useState<SmtDraftRecord[]>(() => listSmtDrafts());
   const [activeDraftId, setActiveDraftId] = useState<string | null>(null);
+  const [showTechnicalDetails, setShowTechnicalDetails] = useDisclosurePreference(
+    'miniDpp.publicSmt.technicalDetails',
+  );
   const pendingDraftRef = useRef<SmtDraftRecord | null>(null);
   const uploadInputRef = useRef<HTMLInputElement>(null);
 
@@ -651,7 +656,7 @@ export default function PublicIdtaSubmodelEditorPage() {
     <div className="space-y-6">
       <PageHeader
         title="IDTA Submodel Template Editor"
-        description="Anonymous AAS developer sandbox for cached IDTA templates"
+        description="Build a template instance with a guided form; advanced AAS/JSON details stay available."
         breadcrumb={<span className="text-xs text-muted-foreground">Tools / IDTA Submodel Editor</span>}
       />
 
@@ -727,53 +732,72 @@ export default function PublicIdtaSubmodelEditorPage() {
             </Select>
           </div>
 
-          {templateDetailQuery.data && (
-            <div className="space-y-2 rounded-md border bg-muted/25 p-3 text-xs">
-              <div className="flex items-center gap-2">
-                <Badge variant="outline">{templateDetailQuery.data.catalog_status}</Badge>
-                <Badge variant="secondary">v{templateDetailQuery.data.latest_version}</Badge>
-              </div>
-              <p>
-                <span className="font-medium">Semantic ID:</span> {templateDetailQuery.data.semantic_id}
-              </p>
-              <p>
-                <span className="font-medium">Repo ref:</span>{' '}
-                {templateDetailQuery.data.source_metadata.source_repo_ref}
-              </p>
-              <p>
-                <span className="font-medium">Source SHA:</span>{' '}
-                {templateDetailQuery.data.source_metadata.source_file_sha ?? 'n/a'}
-              </p>
-            </div>
-          )}
+          {(templateDetailQuery.data || contractQuery.data) && (
+            <Collapsible open={showTechnicalDetails} onOpenChange={setShowTechnicalDetails}>
+              <div className="rounded-md border">
+                <CollapsibleTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="w-full justify-between px-3 py-2 text-left text-sm"
+                    aria-expanded={showTechnicalDetails}
+                  >
+                    <span>Technical details</span>
+                    <ChevronDown className="h-4 w-4" />
+                  </Button>
+                </CollapsibleTrigger>
+                <CollapsibleContent className="space-y-3 border-t p-3">
+                  {templateDetailQuery.data && (
+                    <div className="space-y-2 rounded-md bg-muted/25 p-3 text-xs">
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline">{templateDetailQuery.data.catalog_status}</Badge>
+                        <Badge variant="secondary">v{templateDetailQuery.data.latest_version}</Badge>
+                      </div>
+                      <p>
+                        <span className="font-medium">Semantic ID:</span> {templateDetailQuery.data.semantic_id}
+                      </p>
+                      <p>
+                        <span className="font-medium">Repo ref:</span>{' '}
+                        {templateDetailQuery.data.source_metadata.source_repo_ref}
+                      </p>
+                      <p>
+                        <span className="font-medium">Source SHA:</span>{' '}
+                        {templateDetailQuery.data.source_metadata.source_file_sha ?? 'n/a'}
+                      </p>
+                    </div>
+                  )}
 
-          {contractQuery.data && (
-            <div className="space-y-2 rounded-md border bg-muted/25 p-3 text-xs">
-              <p className="font-medium">Template diagnostics</p>
-              <div className="flex flex-wrap gap-2">
-                <Badge variant={diagnostics.unsupported.length > 0 ? 'destructive' : 'secondary'}>
-                  Unsupported nodes: {diagnostics.unsupported.length}
-                </Badge>
-                <Badge variant={diagnostics.unresolved.length > 0 ? 'destructive' : 'secondary'}>
-                  Unresolved drop-ins: {diagnostics.unresolved.length}
-                </Badge>
+                  {contractQuery.data && (
+                    <div className="space-y-2 rounded-md bg-muted/25 p-3 text-xs">
+                      <p className="font-medium">Template diagnostics</p>
+                      <div className="flex flex-wrap gap-2">
+                        <Badge variant={diagnostics.unsupported.length > 0 ? 'destructive' : 'secondary'}>
+                          Unsupported nodes: {diagnostics.unsupported.length}
+                        </Badge>
+                        <Badge variant={diagnostics.unresolved.length > 0 ? 'destructive' : 'secondary'}>
+                          Unresolved drop-ins: {diagnostics.unresolved.length}
+                        </Badge>
+                      </div>
+                      {diagnostics.unsupported.slice(0, 3).map((entry, index) => (
+                        <p key={`unsupported-${entry.path ?? 'root'}-${index}`} className="text-muted-foreground">
+                          {(entry.path ?? 'root')}: {(entry.reasons ?? []).join(', ') || 'unsupported'}
+                        </p>
+                      ))}
+                      {diagnostics.unresolved.slice(0, 3).map((entry, index) => {
+                        const record = entry as Record<string, unknown>;
+                        const pathValue = typeof record.path === 'string' ? record.path : 'root';
+                        const reasonValue = typeof record.reason === 'string' ? record.reason : 'unresolved';
+                        return (
+                          <p key={`unresolved-${pathValue}-${index}`} className="text-muted-foreground">
+                            {pathValue}: {reasonValue}
+                          </p>
+                        );
+                      })}
+                    </div>
+                  )}
+                </CollapsibleContent>
               </div>
-              {diagnostics.unsupported.slice(0, 3).map((entry, index) => (
-                <p key={`unsupported-${entry.path ?? 'root'}-${index}`} className="text-muted-foreground">
-                  {(entry.path ?? 'root')}: {(entry.reasons ?? []).join(', ') || 'unsupported'}
-                </p>
-              ))}
-              {diagnostics.unresolved.slice(0, 3).map((entry, index) => {
-                const record = entry as Record<string, unknown>;
-                const pathValue = typeof record.path === 'string' ? record.path : 'root';
-                const reasonValue = typeof record.reason === 'string' ? record.reason : 'unresolved';
-                return (
-                  <p key={`unresolved-${pathValue}-${index}`} className="text-muted-foreground">
-                    {pathValue}: {reasonValue}
-                  </p>
-                );
-              })}
-            </div>
+            </Collapsible>
           )}
 
           <div className="space-y-2 rounded-md border p-3">
@@ -832,7 +856,12 @@ export default function PublicIdtaSubmodelEditorPage() {
           ) : !contractQuery.data ? (
             <div className="rounded-md border p-8 text-sm text-muted-foreground">Select a template to start.</div>
           ) : (
-            <SubmodelEditorShell title="Sandbox Workspace" activeViewLabel={activeView === 'preview' ? 'json' : activeView}>
+            <SubmodelEditorShell
+              title="Sandbox Workspace"
+              activeViewLabel={activeView === 'json' || activeView === 'preview' ? 'json' : 'form'}
+              formDescription="Complete the template through a guided form before reviewing technical output."
+              jsonDescription="Use advanced JSON and AAS preview for standards verification."
+            >
               {error && (
                 <Alert variant="destructive">
                   <AlertDescription className="text-xs">{error}</AlertDescription>
@@ -874,8 +903,8 @@ export default function PublicIdtaSubmodelEditorPage() {
 
               <Tabs value={activeView} onValueChange={(value) => handleViewChange(value as 'form' | 'json' | 'preview')}>
                 <TabsList>
-                  <TabsTrigger value="form" disabled={!uiSchema}>Form</TabsTrigger>
-                  <TabsTrigger value="json">Raw JSON</TabsTrigger>
+                  <TabsTrigger value="form" disabled={!uiSchema}>Guided Form</TabsTrigger>
+                  <TabsTrigger value="json">Advanced JSON</TabsTrigger>
                   <TabsTrigger value="preview">AAS JSON Preview</TabsTrigger>
                 </TabsList>
                 <TabsContent value="form">

--- a/frontend/src/features/dpp-outline/components/DppOutlinePane.tsx
+++ b/frontend/src/features/dpp-outline/components/DppOutlinePane.tsx
@@ -41,7 +41,7 @@ function nodeCount(nodes: DppOutlineNode[]): number {
 
 export function DppOutlinePane({
   context,
-  title = 'DPP Structure',
+  title = 'Passport Navigation',
   nodes,
   selectedId,
   onSelectNode,
@@ -99,7 +99,7 @@ export function DppOutlinePane({
             size="icon"
             className="h-7 w-7"
             onClick={paneState.toggleCollapsed}
-            aria-label="Collapse outline"
+            aria-label="Collapse passport navigation"
           >
             <ChevronLeft className="h-4 w-4" />
           </Button>
@@ -112,9 +112,9 @@ export function DppOutlinePane({
           <Input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search structure"
+            placeholder="Search passport fields"
             className="h-8 pl-8 text-xs"
-            aria-label="Search structure outline"
+            aria-label="Search passport navigation"
           />
         </div>
 
@@ -122,6 +122,7 @@ export function DppOutlinePane({
           nodes={filteredNodes}
           selectedId={selectedId}
           onSelectNode={onSelectNode}
+          ariaLabel={title}
           scrollClassName="max-h-[65vh]"
         />
       </div>
@@ -154,7 +155,7 @@ export function DppOutlinePane({
           size="icon"
           className="h-10 w-10"
           onClick={paneState.toggleCollapsed}
-          aria-label="Expand outline"
+          aria-label="Expand passport navigation"
         >
           <ChevronRight className="h-4 w-4" />
         </Button>

--- a/frontend/src/features/dpp-outline/components/DppOutlineTree.tsx
+++ b/frontend/src/features/dpp-outline/components/DppOutlineTree.tsx
@@ -33,7 +33,7 @@ function collectExpandedDefaults(nodes: DppOutlineNode[]): Set<string> {
   const expanded = new Set<string>();
 
   const visit = (node: DppOutlineNode, depth: number) => {
-    if (node.children.length > 0 && depth <= 1) {
+    if (node.children.length > 0 && depth === 0) {
       expanded.add(node.id);
     }
     for (const child of node.children) {
@@ -130,7 +130,7 @@ export function DppOutlineTree({
   nodes,
   selectedId,
   onSelectNode,
-  ariaLabel = 'DPP structure outline',
+  ariaLabel = 'Passport navigation',
   virtualizeThreshold = 180,
   scrollClassName = 'max-h-[65vh]',
 }: DppOutlineTreeProps) {

--- a/frontend/src/features/dpp-outline/components/__tests__/DppOutlinePane.test.tsx
+++ b/frontend/src/features/dpp-outline/components/__tests__/DppOutlinePane.test.tsx
@@ -30,7 +30,7 @@ describe('DppOutlinePane', () => {
   it('shows empty-state message when search has no results', () => {
     render(<DppOutlinePane context="viewer" nodes={nodes} />);
 
-    fireEvent.change(screen.getByLabelText(/Search structure outline/i), {
+    fireEvent.change(screen.getByLabelText(/Search passport navigation/i), {
       target: { value: 'does-not-exist' },
     });
 
@@ -42,7 +42,7 @@ describe('DppOutlinePane', () => {
   it('shows matching nodes when search query matches', () => {
     render(<DppOutlinePane context="viewer" nodes={nodes} />);
 
-    fireEvent.change(screen.getByLabelText(/Search structure outline/i), {
+    fireEvent.change(screen.getByLabelText(/Search passport navigation/i), {
       target: { value: 'manufacturer' },
     });
 

--- a/frontend/src/features/dpp-outline/components/__tests__/DppOutlineTree.test.tsx
+++ b/frontend/src/features/dpp-outline/components/__tests__/DppOutlineTree.test.tsx
@@ -59,6 +59,10 @@ describe('DppOutlineTree', () => {
 
     expect(screen.queryByRole('treeitem', { name: /ManufacturerName/i })).toBeNull();
 
+    const nameplate = screen.getByRole('treeitem', { name: /Nameplate/i });
+    nameplate.focus();
+    fireEvent.keyDown(nameplate, { key: 'ArrowRight' });
+
     const manufacturerSection = screen.getByRole('treeitem', { name: /ManufacturerData/i });
     manufacturerSection.focus();
     fireEvent.keyDown(manufacturerSection, { key: 'ArrowRight' });

--- a/frontend/src/features/editor/pages/SubmodelEditorPage.tsx
+++ b/frontend/src/features/editor/pages/SubmodelEditorPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from 'react-oidc-context';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, ListTree } from 'lucide-react';
 import { apiFetch, getApiErrorMessage, tenantApiFetch } from '@/lib/api';
 import { useTenantSlug } from '@/lib/tenant';
 import { buildSubmodelData } from '@/features/editor/utils/submodelData';
@@ -58,6 +58,7 @@ import { DppOutlinePane } from '@/features/dpp-outline/components/DppOutlinePane
 import { buildSubmodelEditorOutline } from '@/features/dpp-outline/builders/buildSubmodelEditorOutline';
 import { useOutlineScrollSync } from '@/features/dpp-outline/hooks/useOutlineScrollSync';
 import type { DppOutlineNode } from '@/features/dpp-outline/types';
+import { useDisclosurePreference } from '@/features/progressive-disclosure/useDisclosurePreference';
 
 class AmbiguousBindingError extends Error {
   candidates: string[];
@@ -518,6 +519,10 @@ export default function SubmodelEditorPage() {
   const [saveAttempted, setSaveAttempted] = useState(false);
   const [rebuildConfirmOpen, setRebuildConfirmOpen] = useState(false);
   const [hasAppliedInitialFocus, setHasAppliedInitialFocus] = useState(false);
+  const [showOutline, setShowOutline] = useDisclosurePreference('miniDpp.submodel.showOutline');
+  const [showTechnicalDetails, setShowTechnicalDetails] = useDisclosurePreference(
+    'miniDpp.submodel.technicalDetails',
+  );
   const suppressScrollSyncUntilRef = useRef(0);
 
   // Sync RHF defaults when initial data loads
@@ -948,6 +953,7 @@ export default function SubmodelEditorPage() {
 
   return (
     <div className="space-y-4">
+      {showOutline && (
       <DppOutlinePane
         context="submodel"
         mobile
@@ -956,8 +962,10 @@ export default function SubmodelEditorPage() {
         selectedId={selectedOutlineNodeId}
         onSelectNode={handleOutlineNodeSelect}
       />
+      )}
 
-      <div className="xl:grid xl:grid-cols-[minmax(260px,340px)_1fr] xl:gap-6">
+      <div className={showOutline ? 'xl:grid xl:grid-cols-[minmax(260px,340px)_1fr] xl:gap-6' : ''}>
+        {showOutline && (
         <DppOutlinePane
           context="submodel"
           className="hidden xl:block"
@@ -965,12 +973,13 @@ export default function SubmodelEditorPage() {
           selectedId={selectedOutlineNodeId}
           onSelectNode={handleOutlineNodeSelect}
         />
+        )}
 
         <div className="space-y-6">
       {/* Header */}
       <PageHeader
-        title="Edit Submodel"
-        description={`Template: ${templateKey}`}
+        title="Guided Submodel Form"
+        description={`Complete required passport information for template: ${templateKey}`}
         breadcrumb={
           <Button
             variant="ghost"
@@ -983,13 +992,29 @@ export default function SubmodelEditorPage() {
         }
         actions={
           contract ? (
-            <Badge variant="secondary">{contract.idta_version}</Badge>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setShowOutline(!showOutline)}
+                aria-expanded={showOutline}
+              >
+                <ListTree className="h-4 w-4 mr-2" />
+                {showOutline ? 'Hide navigation outline' : 'Show navigation outline'}
+              </Button>
+              <Badge variant="secondary">{contract.idta_version}</Badge>
+            </div>
           ) : undefined
         }
       />
 
       {/* Editor Card */}
-      <SubmodelEditorShell title="Submodel Data" activeViewLabel={activeView}>
+      <SubmodelEditorShell
+        title="Guided Form"
+        activeViewLabel={activeView === 'json' ? 'json' : 'form'}
+        formDescription="Complete the business fields first. Technical JSON remains available for expert review."
+        jsonDescription="Edit the raw submodel JSON only when the guided form is not enough."
+      >
           <p className="sr-only" aria-live="polite">
             {updateMutation.isPending ? 'Saving submodel changes' : ''}
           </p>
@@ -1032,7 +1057,12 @@ export default function SubmodelEditorPage() {
               className="rounded-md border bg-muted/20 p-3"
             >
               <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-                <p className="text-sm font-medium">Section Progress</p>
+                <div>
+                  <p className="text-sm font-medium">Required Information Progress</p>
+                  <p className="text-xs text-muted-foreground">
+                    Use this summary to find incomplete required fields before saving.
+                  </p>
+                </div>
                 <Badge variant="outline">
                   {completedRequiredAcrossSections}/{totalRequiredAcrossSections} required ({overallRequiredPercent}%)
                 </Badge>
@@ -1105,10 +1135,16 @@ export default function SubmodelEditorPage() {
 
           <Tabs value={activeView} onValueChange={(v) => handleViewChange(v as 'form' | 'json')}>
             <TabsList>
-              <TabsTrigger value="form" disabled={!uiSchema}>Form</TabsTrigger>
-              <TabsTrigger value="json">JSON</TabsTrigger>
+              <TabsTrigger value="form" disabled={!uiSchema}>Guided Form</TabsTrigger>
+              <TabsTrigger value="json">Advanced JSON</TabsTrigger>
             </TabsList>
             <TabsContent value="form">
+              <div className="mb-4 rounded-md border bg-muted/20 p-3">
+                <h2 className="text-sm font-semibold">Section fields</h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Fill in the required passport data. Use the navigation outline only when you need to jump through long templates.
+                </p>
+              </div>
               <div className={cn(!actionState.canUpdate && 'opacity-90')}>
                 <fieldset disabled={!actionState.canUpdate} className="space-y-4">
                   {hasDefinitionElements ? (
@@ -1193,13 +1229,18 @@ export default function SubmodelEditorPage() {
           )}
       </SubmodelEditorShell>
 
-      {/* Debug panels */}
+      {/* Technical details */}
       {templateDefinition && (
-        <Card>
-          <Collapsible>
+        <Collapsible open={showTechnicalDetails} onOpenChange={setShowTechnicalDetails}>
+          <Card>
             <CollapsibleTrigger asChild>
               <Button variant="ghost" className="w-full justify-between p-6">
-                Template Definition (read-only)
+                <span className="text-left">
+                  <span className="block text-base font-semibold">Template Contract Details</span>
+                  <span className="mt-1 block text-xs font-normal text-muted-foreground">
+                    Advanced AAS/IDTA structure for auditors, developers, and template debugging.
+                  </span>
+                </span>
                 <ChevronRight className="h-4 w-4" />
               </Button>
             </CollapsibleTrigger>
@@ -1210,8 +1251,8 @@ export default function SubmodelEditorPage() {
                 </pre>
               </CardContent>
             </CollapsibleContent>
-          </Collapsible>
-        </Card>
+          </Card>
+        </Collapsible>
       )}
         </div>
       </div>

--- a/frontend/src/features/editor/pages/__tests__/SubmodelEditorPage.progress.test.tsx
+++ b/frontend/src/features/editor/pages/__tests__/SubmodelEditorPage.progress.test.tsx
@@ -126,6 +126,7 @@ const templateContract = {
 describe('SubmodelEditorPage progress and rebuild strategy', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
     if (!('scrollIntoView' in HTMLElement.prototype)) {
       Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
         configurable: true,
@@ -167,7 +168,7 @@ describe('SubmodelEditorPage progress and rebuild strategy', () => {
     renderEditor();
 
     await waitFor(() => {
-      expect(screen.getByText(/Section Progress/i)).toBeTruthy();
+      expect(screen.getByText(/Required Information Progress/i)).toBeTruthy();
     });
 
     expect(screen.getAllByText(/ManufacturerData/i).length).toBeGreaterThan(0);
@@ -217,6 +218,11 @@ describe('SubmodelEditorPage progress and rebuild strategy', () => {
       renderEditor(
         '/console/dpps/dpp-1/edit/digital-nameplate?focus_path=ManufacturerData.ManufacturerName',
       );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Show navigation outline/i })).toBeTruthy();
+      });
+      fireEvent.click(screen.getByRole('button', { name: /Show navigation outline/i }));
 
       await waitFor(() => {
         expect(screen.getByTestId('dpp-outline-submodel-desktop')).toBeTruthy();

--- a/frontend/src/features/progressive-disclosure/useDisclosurePreference.ts
+++ b/frontend/src/features/progressive-disclosure/useDisclosurePreference.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+function readStoredBoolean(key: string, fallback: boolean): boolean {
+  if (typeof window === 'undefined') return fallback;
+  const raw = window.localStorage.getItem(key);
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  return fallback;
+}
+
+export function useDisclosurePreference(
+  key: string,
+  fallback = false,
+): [boolean, (value: boolean) => void] {
+  const [value, setValue] = useState<boolean>(() => readStoredBoolean(key, fallback));
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(key, String(value));
+  }, [key, value]);
+
+  return [value, setValue];
+}

--- a/frontend/src/features/publisher/__tests__/DPPEditorPage.actionGating.test.tsx
+++ b/frontend/src/features/publisher/__tests__/DPPEditorPage.actionGating.test.tsx
@@ -121,6 +121,7 @@ describe('DPPEditorPage action gating', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
 
     apiFetchMock.mockImplementation((path: string) => {
       if (path === '/api/v1/templates') {
@@ -172,10 +173,11 @@ describe('DPPEditorPage action gating', () => {
     renderEditor();
 
     await waitFor(() => {
-      expect(screen.getByTestId('dpp-refresh-rebuild')).toBeTruthy();
+      expect(screen.getByText(/^Data Sections$/)).toBeTruthy();
     });
+    await userEvent.setup().click(screen.getByRole('button', { name: /Technical Tools/i }));
 
-    expect((screen.getByRole('button', { name: /publish/i }) as HTMLButtonElement).disabled).toBe(false);
+    expect((screen.getByRole('button', { name: /publish passport/i }) as HTMLButtonElement).disabled).toBe(false);
     expect((screen.getByTestId('dpp-refresh-rebuild') as HTMLButtonElement).disabled).toBe(false);
     expect((screen.getByRole('button', { name: /capture event/i }) as HTMLButtonElement).disabled).toBe(false);
 
@@ -204,10 +206,11 @@ describe('DPPEditorPage action gating', () => {
     renderEditor();
 
     await waitFor(() => {
-      expect(screen.getByTestId('dpp-refresh-rebuild')).toBeTruthy();
+      expect(screen.getByText(/^Data Sections$/)).toBeTruthy();
     });
+    await userEvent.setup().click(screen.getByRole('button', { name: /Technical Tools/i }));
 
-    expect((screen.getByRole('button', { name: /publish/i }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: /publish passport/i }) as HTMLButtonElement).disabled).toBe(true);
     expect((screen.getByTestId('dpp-refresh-rebuild') as HTMLButtonElement).disabled).toBe(true);
     expect((screen.getByRole('button', { name: /capture event/i }) as HTMLButtonElement).disabled).toBe(true);
 
@@ -235,12 +238,13 @@ describe('DPPEditorPage action gating', () => {
     renderEditor();
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /export/i })).toBeTruthy();
+      expect(screen.getByRole('button', { name: /Technical Tools/i })).toBeTruthy();
     });
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole('button', { name: /export/i }));
-    expect(await screen.findByText(/QR Code/i)).toBeTruthy();
+    await user.click(screen.getByRole('button', { name: /Technical Tools/i }));
+    await user.click(screen.getByRole('button', { name: /^Export$/i }));
+    expect(await screen.findByRole('menuitem', { name: /QR Code/i })).toBeTruthy();
   });
 
   it('blocks refresh/rebuild when archived even if can_update is true', async () => {
@@ -264,8 +268,9 @@ describe('DPPEditorPage action gating', () => {
     renderEditor();
 
     await waitFor(() => {
-      expect(screen.getByTestId('dpp-refresh-rebuild')).toBeTruthy();
+      expect(screen.getByRole('button', { name: /Technical Tools/i })).toBeTruthy();
     });
+    await userEvent.setup().click(screen.getByRole('button', { name: /Technical Tools/i }));
 
     expect((screen.getByTestId('dpp-refresh-rebuild') as HTMLButtonElement).disabled).toBe(true);
     expect(screen.queryByRole('button', { name: /publish/i })).toBeNull();
@@ -292,10 +297,11 @@ describe('DPPEditorPage action gating', () => {
     renderEditor();
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /export/i })).toBeTruthy();
+      expect(screen.getByRole('button', { name: /Technical Tools/i })).toBeTruthy();
     });
+    await userEvent.setup().click(screen.getByRole('button', { name: /Technical Tools/i }));
 
-    expect((screen.getByRole('button', { name: /export/i }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: /^Export$/i }) as HTMLButtonElement).disabled).toBe(true);
     expect(screen.getByText(/View all events/i)).toBeTruthy();
   });
 });

--- a/frontend/src/features/publisher/__tests__/DPPEditorPage.outline.test.tsx
+++ b/frontend/src/features/publisher/__tests__/DPPEditorPage.outline.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import DPPEditorPage from '../pages/DPPEditorPage';
@@ -72,7 +72,9 @@ function renderEditor() {
 
 describe('DPPEditorPage outline integration', () => {
   beforeEach(() => {
+    cleanup();
     vi.clearAllMocks();
+    window.localStorage.clear();
 
     apiFetchMock.mockImplementation((path: string) => {
       if (path === '/api/v1/templates') {
@@ -161,21 +163,31 @@ describe('DPPEditorPage outline integration', () => {
     renderEditor();
 
     await waitFor(() => {
-      expect(screen.getByTestId('dpp-outline-editor-desktop')).toBeTruthy();
+      expect(screen.getByRole('button', { name: /Show navigation outline/i })).toBeTruthy();
     });
+    fireEvent.click(screen.getByRole('button', { name: /Show navigation outline/i }));
 
     expect(screen.getByText('Sections')).toBeTruthy();
-    expect(screen.getByText('Leaf Fields')).toBeTruthy();
-    expect(screen.getByText('Validation Signals')).toBeTruthy();
+    expect(screen.getByText('Data Fields')).toBeTruthy();
+    expect(screen.getByText('Rule Signals')).toBeTruthy();
     expect(screen.queryByRole('tree', { name: /Nameplate structure/i })).toBeNull();
   });
 
   it('navigates to submodel editor with focus query params when a tree node is selected', async () => {
     renderEditor();
 
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Show navigation outline/i })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Show navigation outline/i }));
+
     const outlinePane = await waitFor(() =>
       screen.getByTestId('dpp-outline-editor-desktop'),
     );
+
+    const nameplate = within(outlinePane).getByRole('treeitem', { name: /Nameplate/i });
+    nameplate.focus();
+    fireEvent.keyDown(nameplate, { key: 'ArrowRight' });
 
     fireEvent.click(
       within(outlinePane).getByRole('treeitem', { name: /ManufacturerData/i }),

--- a/frontend/src/features/publisher/__tests__/DPPEditorPage.refreshRebuild.test.tsx
+++ b/frontend/src/features/publisher/__tests__/DPPEditorPage.refreshRebuild.test.tsx
@@ -64,6 +64,7 @@ function renderEditor() {
 describe('DPPEditorPage refresh & rebuild', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
 
     apiFetchMock.mockImplementation((path: string) => {
       if (path === '/api/v1/templates') {
@@ -169,8 +170,9 @@ describe('DPPEditorPage refresh & rebuild', () => {
     renderEditor();
 
     await waitFor(() => {
-      expect(screen.getByTestId('dpp-refresh-rebuild')).toBeTruthy();
+      expect(screen.getByRole('button', { name: /Technical Tools/i })).toBeTruthy();
     });
+    fireEvent.click(screen.getByRole('button', { name: /Technical Tools/i }));
 
     fireEvent.click(screen.getByTestId('dpp-refresh-rebuild'));
 

--- a/frontend/src/features/publisher/pages/DPPEditorPage.tsx
+++ b/frontend/src/features/publisher/pages/DPPEditorPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from 'react-oidc-context';
-import { ArrowLeft, Send, Download, QrCode, Edit3, RefreshCw, Copy, Check, Activity, Plus, History, Filter } from 'lucide-react';
+import { ArrowLeft, Send, Download, QrCode, Edit3, RefreshCw, Copy, Check, Activity, Plus, History, Filter, ChevronDown, ListTree, ShieldCheck } from 'lucide-react';
 import { apiFetch, getApiErrorMessage, tenantApiFetch } from '@/lib/api';
 import { fetchEPCISEvents } from '@/features/epcis/lib/epcisApi';
 import { EPCISTimeline } from '@/features/epcis/components/EPCISTimeline';
@@ -18,6 +18,7 @@ import { classifyElement, ESPR_CATEGORIES } from '@/features/viewer/utils/esprCa
 import { DppOutlinePane } from '@/features/dpp-outline/components/DppOutlinePane';
 import { buildEditorOutline } from '@/features/dpp-outline/builders/buildEditorOutline';
 import type { DppOutlineNode } from '@/features/dpp-outline/types';
+import { useDisclosurePreference } from '@/features/progressive-disclosure/useDisclosurePreference';
 import { PageHeader } from '@/components/page-header';
 import { ErrorBanner } from '@/components/error-banner';
 import { ConfirmDialog } from '@/components/confirm-dialog';
@@ -26,6 +27,11 @@ import { StatusBadge } from '@/components/status-badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -231,6 +237,13 @@ export default function DPPEditorPage() {
   const [completionFilter, setCompletionFilter] = useState<CompletionFilter>('all');
   const [riskFilter, setRiskFilter] = useState<RiskFilter>('all');
   const [submodelSort, setSubmodelSort] = useState<SubmodelSortKey>('risk-desc');
+  const [showOutline, setShowOutline] = useDisclosurePreference('miniDpp.publisher.showOutline');
+  const [showTechnicalTools, setShowTechnicalTools] = useDisclosurePreference(
+    'miniDpp.publisher.technicalTools',
+  );
+  const [showTechnicalMetadata, setShowTechnicalMetadata] = useDisclosurePreference(
+    'miniDpp.publisher.technicalMetadata',
+  );
 
   const { data: dpp, isLoading } = useQuery({
     queryKey: ['dpp', tenantSlug, dppId],
@@ -454,6 +467,11 @@ export default function DPPEditorPage() {
       }),
     [dpp?.id, dppId, visibleSubmodelCards],
   );
+  const incompleteSectionCount = submodelCards.filter(
+    (entry) => entry.completionPercent !== null && entry.completionPercent < 100,
+  ).length;
+  const highRiskSectionCount = submodelCards.filter((entry) => entry.risk === 'high').length;
+  const latestTraceabilityCount = epcisData?.eventList?.length ?? 0;
 
   const handleOutlineNodeSelect = (node: DppOutlineNode) => {
     setSelectedOutlineNodeId(node.id);
@@ -525,6 +543,7 @@ export default function DPPEditorPage() {
 
   return (
     <div className="space-y-4">
+      {showOutline && (
       <DppOutlinePane
         context="editor"
         mobile
@@ -533,8 +552,10 @@ export default function DPPEditorPage() {
         selectedId={selectedOutlineNodeId}
         onSelectNode={handleOutlineNodeSelect}
       />
+      )}
 
-      <div className="xl:grid xl:grid-cols-[minmax(260px,340px)_1fr] xl:gap-6">
+      <div className={showOutline ? 'xl:grid xl:grid-cols-[minmax(260px,340px)_1fr] xl:gap-6' : ''}>
+        {showOutline && (
         <DppOutlinePane
           context="editor"
           className="hidden xl:block"
@@ -542,12 +563,13 @@ export default function DPPEditorPage() {
           selectedId={selectedOutlineNodeId}
           onSelectNode={handleOutlineNodeSelect}
         />
+        )}
 
         <div className="space-y-6">
       {/* Header */}
       <PageHeader
         title={manufacturerPartId || 'DPP Editor'}
-        description={`ID: ${dpp.id}`}
+        description={`Passport ID: ${dpp.id}`}
         breadcrumb={
           <Button
             variant="ghost"
@@ -561,54 +583,15 @@ export default function DPPEditorPage() {
         }
         actions={
           <>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline" disabled={!actionState.canExport}>
-                  <Download className="h-4 w-4 mr-2" />
-                  Export
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                <DropdownMenuItem onClick={() => { void handleExport('json'); }}>
-                  Export JSON
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => { void handleExport('pdf'); }}>
-                  Export PDF
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => { void handleExport('aasx'); }}>
-                  Export AASX
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => { void handleExport('jsonld'); }}>
-                  Export JSON-LD
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => { void handleExport('turtle'); }}>
-                  Export Turtle
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => { void handleExport('xml'); }}>
-                  Export XML
-                </DropdownMenuItem>
-                {actionState.canGenerateQr && (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem onClick={() => { void handleQrCode(); }}>
-                      <QrCode className="h-4 w-4 mr-2" />
-                      QR Code
-                    </DropdownMenuItem>
-                  </>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-            {dpp.status === 'draft' && (
-              <Button
-                onClick={() => setPublishConfirmOpen(true)}
-                disabled={publishMutation.isPending || !actionState.canPublish}
-                variant="default"
-                title={publishBlocked ? publishBlockers[0] : undefined}
-              >
-                <Send className="h-4 w-4 mr-2" />
-                {publishMutation.isPending ? 'Publishing...' : 'Publish'}
-              </Button>
-            )}
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setShowOutline(!showOutline)}
+              aria-expanded={showOutline}
+            >
+              <ListTree className="h-4 w-4 mr-2" />
+              {showOutline ? 'Hide navigation outline' : 'Show navigation outline'}
+            </Button>
           </>
         }
       />
@@ -621,34 +604,51 @@ export default function DPPEditorPage() {
         />
       )}
 
-      {/* Status */}
-      <Card>
-        <CardContent className="flex items-center justify-between p-6">
-          <div className="flex items-center gap-3">
-            <span className="text-sm font-medium">Status</span>
-            <StatusBadge status={dpp.status} />
-          </div>
-          <div className="text-right">
-            <p className="text-sm text-muted-foreground">Revision</p>
-            <p className="text-lg font-bold">#{dpp.current_revision_no || 1}</p>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Asset Information */}
+      {/* Passport Overview */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-lg">Asset Information</CardTitle>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <ShieldCheck className="h-5 w-5" />
+            Passport Overview
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Current publication state, product identifiers, and the next data tasks.
+          </p>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-5">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+            <div className="rounded-md border bg-muted/20 p-3">
+              <p className="text-xs text-muted-foreground">Status</p>
+              <div className="mt-1">
+                <StatusBadge status={dpp.status} />
+              </div>
+            </div>
+            <div className="rounded-md border bg-muted/20 p-3">
+              <p className="text-xs text-muted-foreground">Revision</p>
+              <p className="mt-1 text-xl font-semibold">#{dpp.current_revision_no || 1}</p>
+            </div>
+            <div className="rounded-md border bg-muted/20 p-3">
+              <p className="text-xs text-muted-foreground">Incomplete sections</p>
+              <p className="mt-1 text-xl font-semibold">{incompleteSectionCount}</p>
+            </div>
+            <div className="rounded-md border bg-muted/20 p-3">
+              <p className="text-xs text-muted-foreground">High-risk sections</p>
+              <p className="mt-1 text-xl font-semibold">{highRiskSectionCount}</p>
+            </div>
+            <div className="rounded-md border bg-muted/20 p-3">
+              <p className="text-xs text-muted-foreground">Traceability events</p>
+              <p className="mt-1 text-xl font-semibold">{latestTraceabilityCount}</p>
+            </div>
+          </div>
+
           {requiredAssetIds.length > 0 && (
             <p className="mb-3 text-xs text-muted-foreground">
-              Required specificAssetIds: {requiredAssetIds.join(', ')}
+              Required product identifiers: {requiredAssetIds.join(', ')}
             </p>
           )}
           {missingRequiredAssetIds.length > 0 && (
             <p className="mb-3 text-xs text-destructive">
-              Missing required specificAssetIds: {missingRequiredAssetIds.join(', ')}
+              Missing required product identifiers: {missingRequiredAssetIds.join(', ')}
             </p>
           )}
           <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -662,19 +662,22 @@ export default function DPPEditorPage() {
         </CardContent>
       </Card>
 
-      {/* Submodels */}
+      {/* Data Sections */}
       <Card>
         <CardHeader className="flex-row items-center justify-between">
-          <CardTitle className="text-lg">Submodels</CardTitle>
+          <div>
+            <CardTitle className="text-lg">Data Sections</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Complete the passport one business section at a time.
+            </p>
+          </div>
           <Button
             variant="outline"
             size="sm"
-            onClick={() => refreshRebuildMutation.mutate()}
-            disabled={refreshRebuildMutation.isPending || !actionState.canRefreshRebuild}
-            data-testid="dpp-refresh-rebuild"
+            onClick={() => setShowTechnicalMetadata(!showTechnicalMetadata)}
+            aria-expanded={showTechnicalMetadata}
           >
-            <RefreshCw className={`h-4 w-4 mr-2 ${refreshRebuildMutation.isPending ? 'animate-spin' : ''}`} />
-            {refreshRebuildMutation.isPending ? 'Refreshing...' : 'Refresh & Rebuild'}
+            {showTechnicalMetadata ? 'Hide technical metadata' : 'Show technical metadata'}
           </Button>
         </CardHeader>
         <CardContent>
@@ -816,10 +819,14 @@ export default function DPPEditorPage() {
                               </Badge>
                             )}
                           </div>
-                          <p className="text-xs text-muted-foreground break-all">{String(entry.submodel.id ?? '-')}</p>
-                          {entry.binding?.semantic_id && (
+                          {showTechnicalMetadata && (
+                            <p className="text-xs text-muted-foreground break-all">
+                              AAS ID: {String(entry.submodel.id ?? '-')}
+                            </p>
+                          )}
+                          {showTechnicalMetadata && entry.binding?.semantic_id && (
                             <p className="text-[11px] text-muted-foreground break-all">
-                              semantic: {entry.binding.semantic_id}
+                              Semantic ID: {entry.binding.semantic_id}
                             </p>
                           )}
                         </div>
@@ -833,7 +840,7 @@ export default function DPPEditorPage() {
                           )}
                           <Badge variant="outline">{entry.health.leafCount} leaf fields</Badge>
                           <Badge variant="outline">{entry.health.validationSignals} rule signals</Badge>
-                          {entry.binding?.binding_source && (
+                          {showTechnicalMetadata && entry.binding?.binding_source && (
                             <Badge variant="outline" className="uppercase text-[10px]">
                               {entry.binding.binding_source}
                             </Badge>
@@ -871,11 +878,11 @@ export default function DPPEditorPage() {
                           <dd>{entry.rootNode.children.length}</dd>
                         </div>
                         <div className="rounded-md border bg-muted/20 px-2 py-1">
-                          <dt className="font-medium text-foreground">Leaf Fields</dt>
+                          <dt className="font-medium text-foreground">Data Fields</dt>
                           <dd>{entry.health.leafCount}</dd>
                         </div>
                         <div className="rounded-md border bg-muted/20 px-2 py-1">
-                          <dt className="font-medium text-foreground">Validation Signals</dt>
+                          <dt className="font-medium text-foreground">Rule Signals</dt>
                           <dd>{entry.health.validationSignals}</dd>
                         </div>
                       </dl>
@@ -894,7 +901,7 @@ export default function DPPEditorPage() {
           ) : (
             missingTemplates.length > 0 && (
               <div className="mt-6 border-t pt-4">
-                <h3 className="text-sm font-semibold mb-3">Available templates</h3>
+                <h3 className="text-sm font-semibold mb-3">Add data sections</h3>
                 <div className="grid gap-3 sm:grid-cols-2">
                   {missingTemplates.map((template) => (
                     <Card key={template.id} className="p-0">
@@ -930,60 +937,151 @@ export default function DPPEditorPage() {
         </CardContent>
       </Card>
 
-      {/* Integrity */}
-      {dpp.digest_sha256 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Integrity</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <dl>
-              <div className="space-y-1">
-                <dt className="text-sm font-medium text-muted-foreground">SHA-256 Digest</dt>
-                <dd className="m-0 flex items-start gap-2">
-                  <span className="text-xs font-mono break-all bg-muted p-2 rounded flex-1">
-                    {dpp.digest_sha256}
-                  </span>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="shrink-0 h-8 w-8"
-                    onClick={() => { void handleCopyDigest(); }}
-                    aria-label={copied ? 'Digest copied' : 'Copy digest to clipboard'}
-                    title={copied ? 'Digest copied' : 'Copy digest to clipboard'}
-                  >
-                    {copied ? (
-                      <Check className="h-4 w-4 text-green-600" />
-                    ) : (
-                      <Copy className="h-4 w-4" />
-                    )}
-                  </Button>
-                </dd>
-              </div>
-            </dl>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Revision History */}
+      {/* Publishing and Sharing */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-lg flex items-center gap-2">
-            <History className="h-5 w-5" />
-            Revision History
-          </CardTitle>
+          <CardTitle className="text-lg">Publishing & Sharing</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Publish the passport and prepare access artifacts when the required data is ready.
+          </p>
         </CardHeader>
-        <CardContent>
-          <RevisionHistory dppId={dpp.id} token={token} />
+        <CardContent className="flex flex-wrap gap-2">
+          {dpp.status === 'draft' && (
+            <Button
+              onClick={() => setPublishConfirmOpen(true)}
+              disabled={publishMutation.isPending || !actionState.canPublish}
+              title={publishBlocked ? publishBlockers[0] : undefined}
+            >
+              <Send className="h-4 w-4 mr-2" />
+              {publishMutation.isPending ? 'Publishing...' : 'Publish passport'}
+            </Button>
+          )}
+          <Button
+            variant="outline"
+            onClick={() => { void handleQrCode(); }}
+            disabled={!actionState.canGenerateQr}
+          >
+            <QrCode className="h-4 w-4 mr-2" />
+            Open QR code
+          </Button>
         </CardContent>
       </Card>
 
-      {/* Supply Chain Events */}
+      {/* Technical Tools */}
+      <Collapsible open={showTechnicalTools} onOpenChange={setShowTechnicalTools}>
+        <Card>
+          <CollapsibleTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              className="flex w-full justify-between p-6 text-left"
+              aria-expanded={showTechnicalTools}
+            >
+              <span>
+                <span className="block text-lg font-semibold">Technical Tools</span>
+                <span className="mt-1 block text-sm font-normal text-muted-foreground">
+                  Exports, template rebuilds, integrity digests, and revision history.
+                </span>
+              </span>
+              <ChevronDown className="h-4 w-4 shrink-0" />
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <CardContent className="space-y-5 border-t pt-4">
+              <div className="flex flex-wrap gap-2">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="outline" disabled={!actionState.canExport}>
+                      <Download className="h-4 w-4 mr-2" />
+                      Export
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    <DropdownMenuItem onClick={() => { void handleExport('json'); }}>
+                      Export JSON
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => { void handleExport('pdf'); }}>
+                      Export PDF
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => { void handleExport('aasx'); }}>
+                      Export AASX
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => { void handleExport('jsonld'); }}>
+                      Export JSON-LD
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => { void handleExport('turtle'); }}>
+                      Export Turtle
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => { void handleExport('xml'); }}>
+                      Export XML
+                    </DropdownMenuItem>
+                    {actionState.canGenerateQr && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem onClick={() => { void handleQrCode(); }}>
+                          <QrCode className="h-4 w-4 mr-2" />
+                          QR Code
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <Button
+                  variant="outline"
+                  onClick={() => refreshRebuildMutation.mutate()}
+                  disabled={refreshRebuildMutation.isPending || !actionState.canRefreshRebuild}
+                  data-testid="dpp-refresh-rebuild"
+                >
+                  <RefreshCw className={`h-4 w-4 mr-2 ${refreshRebuildMutation.isPending ? 'animate-spin' : ''}`} />
+                  {refreshRebuildMutation.isPending ? 'Refreshing...' : 'Refresh templates'}
+                </Button>
+              </div>
+
+              {dpp.digest_sha256 && (
+                <dl>
+                  <div className="space-y-1">
+                    <dt className="text-sm font-medium text-muted-foreground">SHA-256 digest</dt>
+                    <dd className="m-0 flex items-start gap-2">
+                      <span className="text-xs font-mono break-all bg-muted p-2 rounded flex-1">
+                        {dpp.digest_sha256}
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="shrink-0 h-8 w-8"
+                        onClick={() => { void handleCopyDigest(); }}
+                        aria-label={copied ? 'Digest copied' : 'Copy digest to clipboard'}
+                        title={copied ? 'Digest copied' : 'Copy digest to clipboard'}
+                      >
+                        {copied ? (
+                          <Check className="h-4 w-4 text-green-600" />
+                        ) : (
+                          <Copy className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </dd>
+                  </div>
+                </dl>
+              )}
+
+              <div>
+                <h2 className="mb-3 flex items-center gap-2 text-base font-semibold">
+                  <History className="h-5 w-5" />
+                  Revision History
+                </h2>
+                <RevisionHistory dppId={dpp.id} token={token} />
+              </div>
+            </CardContent>
+          </CollapsibleContent>
+        </Card>
+      </Collapsible>
+
+      {/* Traceability Evidence */}
       <Card>
         <CardHeader className="flex-row items-center justify-between">
           <CardTitle className="text-lg flex items-center gap-2">
             <Activity className="h-5 w-5" />
-            Supply Chain
+            Traceability Evidence
             {(epcisData?.eventList?.length ?? 0) > 0 && (
               <Badge variant="secondary" className="ml-1">
                 {epcisData!.eventList.length}

--- a/frontend/src/features/submodels/__tests__/accessibility.audit.test.tsx
+++ b/frontend/src/features/submodels/__tests__/accessibility.audit.test.tsx
@@ -149,6 +149,7 @@ describe('Submodel UX accessibility', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
 
     apiFetchMock.mockImplementation((path: string) => {
       if (path === '/api/v1/templates') {
@@ -217,6 +218,8 @@ describe('Submodel UX accessibility', () => {
       <DPPEditorPage />,
     );
 
+    const technicalTools = await screen.findByRole('button', { name: /Technical Tools/i });
+    fireEvent.click(technicalTools);
     const refreshButton = await screen.findByTestId('dpp-refresh-rebuild');
     expect(refreshButton).toBeTruthy();
 
@@ -235,15 +238,15 @@ describe('Submodel UX accessibility', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /Edit Submodel/i })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: /Guided Submodel Form/i })).toBeTruthy();
     });
 
     const a11y = await axe(container);
     expect(a11y.violations, JSON.stringify(a11y.violations, null, 2)).toHaveLength(0);
 
     const user = userEvent.setup();
-    const formTab = screen.getByRole('tab', { name: 'Form' });
-    const jsonTab = screen.getByRole('tab', { name: 'JSON' });
+    const formTab = screen.getByRole('tab', { name: 'Guided Form' });
+    const jsonTab = screen.getByRole('tab', { name: 'Advanced JSON' });
 
     formTab.focus();
     expect(document.activeElement).toBe(formTab);
@@ -257,7 +260,7 @@ describe('Submodel UX accessibility', () => {
     const { container } = renderInApp('/t/default/dpp/abc-123', '/t/:tenantSlug/dpp/:dppId', <DPPViewerPage />);
 
     await waitFor(() => {
-      expect(screen.getByText(/Product Information/i)).toBeTruthy();
+      expect(screen.getAllByText(/^Passport Details$/).length).toBeGreaterThan(0);
     });
 
     const a11y = await axe(container);

--- a/frontend/src/features/submodels/components/SubmodelNodeTree.tsx
+++ b/frontend/src/features/submodels/components/SubmodelNodeTree.tsx
@@ -57,7 +57,7 @@ function NodeItem({
         <p className="mt-2 text-sm break-all">{formatValue(node.value)}</p>
         {showSemanticMeta && node.meta.semanticId && (
           <p className="mt-2 text-[11px] text-muted-foreground break-all">
-            semantic: {node.meta.semanticId}
+            Semantic ID: {node.meta.semanticId}
           </p>
         )}
       </div>
@@ -98,7 +98,7 @@ function NodeItem({
       <CollapsibleContent className="space-y-2 px-3 pb-3">
         {showSemanticMeta && node.meta.semanticId && (
           <p className="text-[11px] text-muted-foreground break-all">
-            semantic: {node.meta.semanticId}
+            Semantic ID: {node.meta.semanticId}
           </p>
         )}
         {node.children.map((child) => (

--- a/frontend/src/features/viewer/components/CategorySection.tsx
+++ b/frontend/src/features/viewer/components/CategorySection.tsx
@@ -7,9 +7,14 @@ import { buildViewerOutlineKey } from '../utils/outlineKey';
 interface CategorySectionProps {
   category: ESPRCategory;
   elements: ClassifiedNode[];
+  showTechnicalMetadata?: boolean;
 }
 
-export function CategorySection({ category, elements }: CategorySectionProps) {
+export function CategorySection({
+  category,
+  elements,
+  showTechnicalMetadata = false,
+}: CategorySectionProps) {
   if (elements.length === 0) return null;
 
   const Icon = category.icon;
@@ -34,14 +39,18 @@ export function CategorySection({ category, elements }: CategorySectionProps) {
                 value={element.value}
               />
               <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
-                <span>from {element.submodelIdShort}</span>
-                <span aria-hidden>•</span>
-                <span className="break-all">{element.path}</span>
-                {element.semanticId && (
+                <span>Source: {element.submodelIdShort}</span>
+                {showTechnicalMetadata && (
+                  <>
+                    <span aria-hidden>•</span>
+                    <span className="break-all">{element.path}</span>
+                  </>
+                )}
+                {showTechnicalMetadata && element.semanticId && (
                   <>
                     <span aria-hidden>•</span>
                     <Badge variant="outline" className="text-[10px]">
-                      semantic
+                      semantic ID
                     </Badge>
                   </>
                 )}

--- a/frontend/src/features/viewer/components/DPPHeader.tsx
+++ b/frontend/src/features/viewer/components/DPPHeader.tsx
@@ -43,7 +43,7 @@ export function DPPHeader({ productName, dppId, status, assetIds }: DPPHeaderPro
               <StatusBadge status={status} />
             </div>
             <h1 className="text-2xl font-bold tracking-tight">{productName}</h1>
-            <p className="mt-1 text-sm text-muted-foreground font-mono">ID: {dppId}</p>
+            <p className="mt-1 text-sm text-muted-foreground font-mono">Passport ID: {dppId}</p>
           </div>
         </div>
         {assetIds && Object.keys(assetIds).length > 0 && (

--- a/frontend/src/features/viewer/components/ESPRTabs.tsx
+++ b/frontend/src/features/viewer/components/ESPRTabs.tsx
@@ -7,9 +7,15 @@ interface ESPRTabsProps {
   classified: Record<string, ClassifiedNode[]>;
   value?: string;
   onValueChange?: (value: string) => void;
+  showTechnicalMetadata?: boolean;
 }
 
-export function ESPRTabs({ classified, value, onValueChange }: ESPRTabsProps) {
+export function ESPRTabs({
+  classified,
+  value,
+  onValueChange,
+  showTechnicalMetadata = false,
+}: ESPRTabsProps) {
   // Find first non-empty category for default tab
   const defaultTab = ESPR_CATEGORIES.find(c => (classified[c.id]?.length ?? 0) > 0)?.id ?? 'identity';
   const controlled = typeof value === 'string';
@@ -35,7 +41,11 @@ export function ESPRTabs({ classified, value, onValueChange }: ESPRTabsProps) {
       </TabsList>
       {ESPR_CATEGORIES.map(category => (
         <TabsContent key={category.id} value={category.id} className="mt-4">
-          <CategorySection category={category} elements={classified[category.id] ?? []} />
+          <CategorySection
+            category={category}
+            elements={classified[category.id] ?? []}
+            showTechnicalMetadata={showTechnicalMetadata}
+          />
           {(classified[category.id]?.length ?? 0) === 0 && (
             <div className="text-center py-8 text-sm text-muted-foreground">
               No {category.label.toLowerCase()} data available for this product.

--- a/frontend/src/features/viewer/pages/DPPViewerPage.tsx
+++ b/frontend/src/features/viewer/pages/DPPViewerPage.tsx
@@ -11,7 +11,7 @@ import { ErrorBanner } from '@/components/error-banner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Button } from '@/components/ui/button';
-import { ChevronDown, Activity } from 'lucide-react';
+import { ChevronDown, Activity, ListTree, ShieldCheck } from 'lucide-react';
 import { DPPHeader } from '../components/DPPHeader';
 import { ESPRTabs } from '../components/ESPRTabs';
 import { RawSubmodelTree } from '../components/RawSubmodelTree';
@@ -24,6 +24,8 @@ import type { DppOutlineNode } from '@/features/dpp-outline/types';
 import type { PublicDPPResponse } from '@/api/types';
 import { emitSubmodelUxMetric } from '@/features/submodels/telemetry/uxTelemetry';
 import { resolveSubmodelUxRollout } from '@/features/submodels/featureFlags';
+import { useDisclosurePreference } from '@/features/progressive-disclosure/useDisclosurePreference';
+import { Switch } from '@/components/ui/switch';
 
 async function fetchDPP(
   dppId: string,
@@ -87,6 +89,13 @@ export default function DPPViewerPage() {
   const [activeCategory, setActiveCategory] = useState(defaultCategory);
   const [selectedOutlineNodeId, setSelectedOutlineNodeId] = useState<string | null>(null);
   const [pendingScrollOutlineKey, setPendingScrollOutlineKey] = useState<string | null>(null);
+  const [showOutline, setShowOutline] = useDisclosurePreference('miniDpp.viewer.showOutline');
+  const [showTechnicalDetails, setShowTechnicalDetails] = useDisclosurePreference(
+    'miniDpp.viewer.technicalDetails',
+  );
+  const [showTechnicalMetadata, setShowTechnicalMetadata] = useDisclosurePreference(
+    'miniDpp.viewer.technicalMetadata',
+  );
   const suppressScrollSyncUntilRef = useRef(0);
   const outlineNodes = useMemo(
     () =>
@@ -113,6 +122,32 @@ export default function DPPViewerPage() {
   const productName =
     (dpp?.asset_ids?.manufacturerPartId as string) || 'Digital Product Passport';
   const epcisEvents = epcisData?.eventList ?? [];
+  const passportFacts = useMemo(() => {
+    const facts: Array<{ label: string; value: unknown }> = [];
+    const preferredLabels = ['ManufacturerName', 'Manufacturer', 'ProductName', 'SerialNumber', 'TotalCO2', 'Mass'];
+    const seen = new Set<string>();
+    const allFields = Object.values(classified)
+      .flat()
+      .filter((field) => field.value !== null && field.value !== undefined && field.value !== '');
+
+    for (const label of preferredLabels) {
+      const match = allFields.find((field) => field.label === label);
+      if (match && !seen.has(match.label)) {
+        facts.push({ label: match.label, value: match.value });
+        seen.add(match.label);
+      }
+      if (facts.length >= 6) return facts;
+    }
+
+    for (const field of allFields) {
+      if (seen.has(field.label)) continue;
+      facts.push({ label: field.label, value: field.value });
+      seen.add(field.label);
+      if (facts.length >= 6) break;
+    }
+
+    return facts;
+  }, [classified]);
 
   useEffect(() => {
     setActiveCategory(defaultCategory);
@@ -214,7 +249,7 @@ export default function DPPViewerPage() {
 
   return (
     <div className="space-y-4">
-      {submodels.length > 0 && (
+      {submodels.length > 0 && showOutline && (
         <DppOutlinePane
           context="viewer"
           mobile
@@ -225,8 +260,8 @@ export default function DPPViewerPage() {
         />
       )}
 
-      <div className="xl:grid xl:grid-cols-[minmax(250px,320px)_1fr] xl:gap-6">
-        {submodels.length > 0 ? (
+      <div className={showOutline ? 'xl:grid xl:grid-cols-[minmax(250px,320px)_1fr] xl:gap-6' : ''}>
+        {submodels.length > 0 && showOutline ? (
           <DppOutlinePane
             context="viewer"
             className="hidden xl:block"
@@ -234,9 +269,7 @@ export default function DPPViewerPage() {
             selectedId={selectedOutlineNodeId}
             onSelectNode={handleOutlineNodeSelect}
           />
-        ) : (
-          <div className="hidden xl:block" />
-        )}
+        ) : null}
 
         <div className="space-y-6">
       <DPPHeader
@@ -246,20 +279,98 @@ export default function DPPViewerPage() {
         assetIds={dpp.asset_ids}
       />
 
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <ShieldCheck className="h-5 w-5" />
+            Passport Summary
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Key product facts and trust signals before the technical passport structure.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-md border bg-muted/20 p-3">
+              <p className="text-xs text-muted-foreground">Data sections</p>
+              <p className="mt-1 text-xl font-semibold">{submodels.length}</p>
+            </div>
+            <div className="rounded-md border bg-muted/20 p-3">
+              <p className="text-xs text-muted-foreground">Supply-chain events</p>
+              <p className="mt-1 text-xl font-semibold">{epcisEvents.length}</p>
+            </div>
+            <div className="rounded-md border bg-muted/20 p-3">
+              <p className="text-xs text-muted-foreground">Integrity status</p>
+              <p className="mt-1 text-sm font-medium">
+                {dpp.digest_sha256 ? 'Digest available' : 'No digest published'}
+              </p>
+            </div>
+          </div>
+
+          {passportFacts.length > 0 && (
+            <div>
+              <h2 className="text-sm font-semibold">Important facts</h2>
+              <dl className="mt-2 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {passportFacts.map((fact) => (
+                  <div key={fact.label} className="rounded-md border p-3">
+                    <dt className="text-xs text-muted-foreground">{fact.label}</dt>
+                    <dd className="mt-1 text-sm font-medium break-words">{String(fact.value)}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          )}
+
+          {submodels.length > 0 && (
+            <div className="flex flex-wrap gap-2 border-t pt-3">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setShowOutline(!showOutline)}
+                aria-expanded={showOutline}
+              >
+                <ListTree className="mr-2 h-4 w-4" />
+                {showOutline ? 'Hide navigation outline' : 'Show navigation outline'}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setActiveCategory(defaultCategory)}
+              >
+                View passport details
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
       {/* ESPR Category Tabs */}
       {submodels.length > 0 && (
         <Card>
-          <CardHeader>
-            <CardTitle>Product Information</CardTitle>
+          <CardHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+            <CardTitle>Passport Details</CardTitle>
             <p className="text-sm text-muted-foreground">
-              Organized per EU ESPR (European Sustainability Product Regulation) categories
+              Product data grouped into plain-language sustainability categories.
             </p>
+            </div>
+            <label className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Switch
+                checked={showTechnicalMetadata}
+                onCheckedChange={setShowTechnicalMetadata}
+                aria-label="Show technical metadata"
+              />
+              Show technical metadata
+            </label>
           </CardHeader>
           <CardContent>
             <ESPRTabs
               classified={classified}
               value={activeCategory}
               onValueChange={setActiveCategory}
+              showTechnicalMetadata={showTechnicalMetadata}
             />
           </CardContent>
         </Card>
@@ -285,16 +396,19 @@ export default function DPPViewerPage() {
 
       {/* Raw Data (for advanced users/regulators) */}
       {submodels.length > 0 && rollout.surfaces.viewer && (
-        <Collapsible>
+        <Collapsible open={showTechnicalDetails} onOpenChange={setShowTechnicalDetails}>
           <CollapsibleTrigger asChild>
             <Button variant="ghost" className="w-full justify-between text-muted-foreground">
-              Raw Submodel Data (Advanced)
+              Technical AAS Data
               <ChevronDown className="h-4 w-4" />
             </Button>
           </CollapsibleTrigger>
           <CollapsibleContent>
             <Card className="mt-2">
               <CardContent className="p-4">
+                <p className="mb-3 text-sm text-muted-foreground">
+                  For auditors, developers, and standards verification.
+                </p>
                 <RawSubmodelTree submodels={submodels} />
               </CardContent>
             </Card>

--- a/frontend/src/features/viewer/pages/__tests__/DPPViewerPage.test.tsx
+++ b/frontend/src/features/viewer/pages/__tests__/DPPViewerPage.test.tsx
@@ -81,6 +81,7 @@ describe('DPPViewerPage', () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
+    window.localStorage.clear();
     scrollIntoViewMock = vi.fn();
     Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
       configurable: true,
@@ -111,7 +112,16 @@ describe('DPPViewerPage', () => {
   it('renders outline and switches category tab + scroll target on node click', async () => {
     renderViewer('/t/acme/dpp/abc-123', '/t/:tenantSlug/dpp/:dppId');
 
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Show navigation outline/i })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Show navigation outline/i }));
+
     const outlinePane = await waitFor(() => screen.getByTestId('dpp-outline-viewer-desktop'));
+
+    const carbonNode = within(outlinePane).getByRole('treeitem', { name: /CarbonFootprint/i });
+    carbonNode.focus();
+    fireEvent.keyDown(carbonNode, { key: 'ArrowRight' });
 
     fireEvent.click(within(outlinePane).getByRole('treeitem', { name: /TotalCO2/i }));
 


### PR DESCRIPTION
## Summary
- Add summary-first progressive disclosure across the public viewer, publisher editor, submodel editor, and IDTA sandbox.
- Hide outline/tree and raw AAS/JSON/template internals behind explicit technical controls by default.
- Update user-facing labels, disclosure persistence, and tests for the redesigned flows.

## Validation
- npm test -- --run
- npm run typecheck
- npm run lint
- npm run build
- Browser sanity check on /tools/idta-submodel-editor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added toggleable navigation outline visibility across editor and viewer pages
  * Introduced collapsible "Technical Details" and "Technical Tools" sections to streamline UI
  * Added "Passport Overview" and "Passport Summary" cards with key metrics

* **Improvements**
  * Reorganized technical controls (export, publish, rebuild) into dedicated sections
  * Updated UI labels for clarity: "DPP Structure" → "Passport Navigation", "Section Progress" → "Required Information Progress"
  * Made technical metadata visibility toggleable in viewer
  * Enhanced accessibility with improved labeling throughout

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hadijannat/mini-dpp-platform/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->